### PR TITLE
Report test execution failure

### DIFF
--- a/.github/issues/1-tests-fail-network.md
+++ b/.github/issues/1-tests-fail-network.md
@@ -1,0 +1,13 @@
+# Failing Tests due to Network Reachability
+
+Attempted to run `./mvnw test` on the `work` branch (master branch is missing). Maven wrapper failed to download required components due to lack of network connectivity:
+
+```
+Exception in thread "main" java.net.SocketException: Network is unreachable
+```
+
+This prevents executing the test suite.
+
+## Proposed Fix
+
+Provide an offline Maven repository or pre-populate the necessary dependencies to allow test execution without internet access. Alternatively, configure tests to run without requiring external downloads.


### PR DESCRIPTION
## Summary
- record issue about failing tests due to network errors

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_683faf02c524832da8e4c9ea583aa4bb