### PR TITLE
fix: JavaCodeBlockPolicy default disabled, diagnostic rejection, CompileContext resource leak

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/JavaCodeBlockPolicy.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/JavaCodeBlockPolicy.java
@@ -6,20 +6,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Global policy for Java code block (triple-backtick {@code ```java:ClassName} fence)
  * execution.
  *
- * <p>By default, Java code blocks are <strong>enabled</strong> to preserve backward
- * compatibility with existing users who rely on the dynamic-compilation feature.
- *
- * <p>To opt out of arbitrary code execution — for example when formula sources are
- * supplied by external/untrusted tenants — call {@link #setEnabled(boolean) setEnabled(false)}
- * once at application startup before any {@code JavaCodeCalculatorV3} instances are created:
+ * <p>By default, Java code blocks are <strong>disabled</strong>. Applications that rely on
+ * dynamic compilation of embedded Java code must explicitly opt in by calling
+ * {@link #setEnabled(boolean) setEnabled(true)} once at application startup, before any
+ * {@code JavaCodeCalculatorV3} instances are created:
  *
  * <pre>
- *   JavaCodeBlockPolicy.setEnabled(false);
+ *   JavaCodeBlockPolicy.setEnabled(true);
  * </pre>
  *
- * <p>When disabled, {@code createJavaFromCodedBlock} returns an empty list and code
- * blocks in formulas are silently ignored. The rest of the formula evaluation
- * (arithmetic, variables, if/match, etc.) is unaffected.
+ * <p>When disabled, formulas that contain a Java code block are rejected with a
+ * {@link org.unlaxer.compiler.CompileError} so that callers are aware that part of
+ * their formula was not evaluated.  The rest of the formula evaluation
+ * (arithmetic, variables, if/match, etc.) is unaffected only when no code block is present.
  *
  * <p>This class is thread-safe; the flag may be toggled at any point, but changing it
  * while calculators are being constructed concurrently is not recommended.
@@ -28,14 +27,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class JavaCodeBlockPolicy {
 
-  private static final AtomicBoolean ENABLED = new AtomicBoolean(true);
+  private static final AtomicBoolean ENABLED = new AtomicBoolean(false);
 
   private JavaCodeBlockPolicy() {}
 
   /**
    * Returns whether Java code block execution is currently enabled.
    *
-   * @return {@code true} (default) if code blocks are executed; {@code false} if disabled.
+   * @return {@code true} if code blocks are executed; {@code false} (default) if disabled.
    */
   public static boolean isEnabled() {
     return ENABLED.get();
@@ -44,23 +43,25 @@ public final class JavaCodeBlockPolicy {
   /**
    * Enables or disables Java code block execution globally.
    *
-   * <p>Call with {@code false} to prevent arbitrary code embedded in formula strings
-   * from being compiled and executed at runtime.
+   * <p>Call with {@code true} to allow arbitrary code embedded in formula strings
+   * to be compiled and executed at runtime. Only do this when formula sources are trusted.
    *
-   * <p>The default value is {@code true} to preserve backward compatibility.
+   * <p>The default value is {@code false} (secure by default). Formulas containing a
+   * Java code block will be rejected with a {@link org.unlaxer.compiler.CompileError}
+   * until this flag is explicitly set to {@code true}.
    *
-   * @param enabled {@code true} to allow code block execution (default),
-   *                {@code false} to disable it.
+   * @param enabled {@code true} to allow code block execution (explicit opt-in),
+   *                {@code false} to disable it (default).
    */
   public static void setEnabled(boolean enabled) {
     ENABLED.set(enabled);
   }
 
   /**
-   * Resets the policy to the default enabled state ({@code true}).
-   * Primarily useful in tests to restore state after a test-scoped opt-out.
+   * Resets the policy to the default disabled state ({@code false}).
+   * Primarily useful in tests to restore state after a test-scoped opt-in.
    */
   public static void reset() {
-    ENABLED.set(true);
+    ENABLED.set(false);
   }
 }

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/JavaCodeCalculatorV3.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/JavaCodeCalculatorV3.java
@@ -113,12 +113,10 @@ public class JavaCodeCalculatorV3 extends PreConstructedCalculator
 
     this.source = source;
 
-    CompileContext compileContext = new CompileContext(classLoader,javaFileManagerContext);
-
     dependsOnBy = Optional.empty();
     dependsOns = new ArrayList<>();
 
-    try {
+    try (CompileContext compileContext = new CompileContext(classLoader, javaFileManagerContext)) {
 
       this.className = className;
       formulaHash = MD5.toHex(formula);
@@ -295,13 +293,24 @@ public class JavaCodeCalculatorV3 extends PreConstructedCalculator
 
   static List<InstanceAndByteCode> createJavaFromCodedBlock(TinyExpressionTokens tinyExpressionTokens, CompileContext compileContext) {
 
-    // Opt-out check: if JavaCodeBlockPolicy disables code block execution,
-    // return an empty list without compiling or executing any embedded Java code.
+    List<CodeBlock> codeBlocks = tinyExpressionTokens.codeBlocks;
+
+    // Opt-in check: if JavaCodeBlockPolicy disables code block execution and the formula
+    // contains at least one Java code block, reject with a diagnostic error so callers
+    // are aware that part of their formula is not being evaluated.
     if (!JavaCodeBlockPolicy.isEnabled()) {
+      List<String> javaBlockNames = codeBlocks.stream()
+          .filter(cb -> "java".equalsIgnoreCase(cb.schemeAndIdentifier.scheme))
+          .map(cb -> cb.schemeAndIdentifier.idenitifier)
+          .toList();
+      if (!javaBlockNames.isEmpty()) {
+        throw new org.unlaxer.compiler.CompileError(
+            "Java code block execution is disabled (JavaCodeBlockPolicy). "
+                + "Formula contains Java code block(s): " + javaBlockNames
+                + ". Call JavaCodeBlockPolicy.setEnabled(true) to opt in.");
+      }
       return new ArrayList<>();
     }
-
-    List<CodeBlock> codeBlocks = tinyExpressionTokens.codeBlocks;
 
     List<InstanceAndByteCode> instanceAndByteCodeList = new ArrayList<>();
     for (CodeBlock codeBlock : codeBlocks) {

--- a/src/test/java/org/unlaxer/tinyexpression/evaluator/javacode/JavaCodeBlockPolicyTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/evaluator/javacode/JavaCodeBlockPolicyTest.java
@@ -3,8 +3,8 @@ package org.unlaxer.tinyexpression.evaluator.javacode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.After;
 import org.junit.Before;
@@ -24,12 +24,12 @@ public class JavaCodeBlockPolicyTest {
 
   @Before
   public void setUp() {
-    JavaCodeBlockPolicy.reset(); // ensure default state before each test
+    JavaCodeBlockPolicy.reset(); // ensure default state (disabled) before each test
   }
 
   @After
   public void tearDown() {
-    JavaCodeBlockPolicy.reset(); // restore default after each test
+    JavaCodeBlockPolicy.reset(); // restore default (disabled) after each test
   }
 
   // =========================================================================
@@ -37,8 +37,8 @@ public class JavaCodeBlockPolicyTest {
   // =========================================================================
 
   @Test
-  public void testDefaultIsEnabled() {
-    assertTrue("Java code block execution should be enabled by default",
+  public void testDefaultIsDisabled() {
+    assertFalse("Java code block execution should be disabled by default",
         JavaCodeBlockPolicy.isEnabled());
   }
 
@@ -48,6 +48,7 @@ public class JavaCodeBlockPolicyTest {
 
   @Test
   public void testSetEnabledFalse() {
+    JavaCodeBlockPolicy.setEnabled(true);
     JavaCodeBlockPolicy.setEnabled(false);
     assertFalse("After setEnabled(false), isEnabled() should return false",
         JavaCodeBlockPolicy.isEnabled());
@@ -55,7 +56,6 @@ public class JavaCodeBlockPolicyTest {
 
   @Test
   public void testSetEnabledTrue() {
-    JavaCodeBlockPolicy.setEnabled(false);
     JavaCodeBlockPolicy.setEnabled(true);
     assertTrue("After setEnabled(true), isEnabled() should return true",
         JavaCodeBlockPolicy.isEnabled());
@@ -63,9 +63,9 @@ public class JavaCodeBlockPolicyTest {
 
   @Test
   public void testResetRestoresDefault() {
-    JavaCodeBlockPolicy.setEnabled(false);
+    JavaCodeBlockPolicy.setEnabled(true);
     JavaCodeBlockPolicy.reset();
-    assertTrue("reset() should restore the enabled=true default",
+    assertFalse("reset() should restore the disabled=false default",
         JavaCodeBlockPolicy.isEnabled());
   }
 
@@ -75,7 +75,7 @@ public class JavaCodeBlockPolicyTest {
 
   @Test
   public void testNormalArithmeticUnaffectedWhenCodeBlockDisabled() {
-    JavaCodeBlockPolicy.setEnabled(false);
+    // default is disabled — no need to call setEnabled(false)
 
     SpecifiedExpressionTypes types =
         new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
@@ -93,14 +93,14 @@ public class JavaCodeBlockPolicyTest {
   }
 
   // =========================================================================
-  // Functional: code block section is skipped (no compilation) when disabled
+  // Functional: formula with code block is rejected (with diagnostic) when disabled
   // =========================================================================
 
   @Test
-  public void testCodeBlockSkippedWhenDisabled() {
-    // Formula with an embedded Java code block (the block defines a class).
-    // When JavaCodeBlockPolicy is enabled (default), the class gets compiled.
-    // When disabled, createJavaFromCodedBlock returns empty list — no exception thrown.
+  public void testCodeBlockRejectedWhenDisabled() {
+    // Formula with an embedded Java code block.
+    // When JavaCodeBlockPolicy is disabled (default), createJavaFromCodedBlock throws
+    // a CompileError with a diagnostic message — callers are not silently surprised.
     String formula = "```java:org.unlaxer.test.Policy1\n"
         + "package org.unlaxer.test;\n"
         + "public class Policy1 { public Policy1() {} }\n"
@@ -111,21 +111,40 @@ public class JavaCodeBlockPolicyTest {
         new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
 
-    // Enabled (default): should compile without exception
+    // Disabled (default): should throw CompileError with a diagnostic message
+    try {
+      CalculatorCreatorRegistry.javaCodeCreator()
+          .create(new Source(formula), "PolicyTest_disabled", types, cl);
+      fail("Expected CompileError when Java code block policy is disabled");
+    } catch (org.unlaxer.compiler.CompileError e) {
+      assertTrue("Error message should mention JavaCodeBlockPolicy",
+          e.getMessage() != null && e.getMessage().contains("JavaCodeBlockPolicy"));
+    }
+  }
+
+  @Test
+  public void testCodeBlockCompiledWhenEnabled() {
+    // Explicit opt-in: should compile without exception
+    JavaCodeBlockPolicy.setEnabled(true);
+
+    String formula = "```java:org.unlaxer.test.Policy2\n"
+        + "package org.unlaxer.test;\n"
+        + "public class Policy2 { public Policy2() {} }\n"
+        + "```\n"
+        + "1+1";
+
+    SpecifiedExpressionTypes types =
+        new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
     Calculator calcEnabled = CalculatorCreatorRegistry.javaCodeCreator()
         .create(new Source(formula), "PolicyTest_enabled", types, cl);
     assertNotNull("calculator should be created when policy is enabled", calcEnabled);
 
-    // Disabled: code block compilation skipped, formula evaluation still works
-    JavaCodeBlockPolicy.setEnabled(false);
-    Calculator calcDisabled = CalculatorCreatorRegistry.javaCodeCreator()
-        .create(new Source(formula), "PolicyTest_disabled", types, cl);
-    assertNotNull("calculator should be created even when policy is disabled", calcDisabled);
-
     CalculationContext ctx = CalculationContext.newConcurrentContext();
-    Object result = calcDisabled.apply(ctx);
-    assertNotNull("result should not be null when policy is disabled", result);
-    assertEquals("1+1 should equal 2.0 even with code blocks disabled",
+    Object result = calcEnabled.apply(ctx);
+    assertNotNull("result should not be null when policy is enabled", result);
+    assertEquals("1+1 should equal 2.0 when code blocks enabled",
         2f, ((Number) result).floatValue(), 0.001f);
   }
 }


### PR DESCRIPTION
Closes #15

## Summary

- **Change JavaCodeBlockPolicy default to disabled (opt-in)**: `ENABLED` flag changed from `true` to `false`. Applications that use dynamic Java code block compilation must now explicitly call `JavaCodeBlockPolicy.setEnabled(true)` at startup. The `reset()` method now restores to `false`. This makes the feature secure by default.

- **Add diagnostic rejection when Java block is disabled**: Previously, when the policy was disabled, `createJavaFromCodedBlock` silently returned an empty list even when the formula contained Java code blocks. Now it throws a `CompileError` with a clear message identifying the blocked class names and instructing the caller to opt in. Formulas without any Java code blocks are still processed normally.

- **Fix CompileContext resource leak with try-with-resources**: The `CompileContext` (which holds a `StandardJavaFileManager` and related file managers) was not being closed after compilation in the `JavaCodeCalculatorV3` source-code constructor. It is now wrapped in a `try-with-resources` block, ensuring `close()` is called even on exception paths.

## Test plan

- [ ] `JavaCodeBlockPolicyTest.testDefaultIsDisabled` — verifies new default
- [ ] `JavaCodeBlockPolicyTest.testResetRestoresDefault` — verifies `reset()` restores `false`
- [ ] `JavaCodeBlockPolicyTest.testCodeBlockRejectedWhenDisabled` — verifies `CompileError` with diagnostic is thrown when a formula with a Java code block is evaluated while policy is disabled
- [ ] `JavaCodeBlockPolicyTest.testCodeBlockCompiledWhenEnabled` — verifies code block compiles correctly after explicit opt-in
- [ ] `JavaCodeBlockPolicyTest.testNormalArithmeticUnaffectedWhenCodeBlockDisabled` — verifies plain arithmetic still works when policy is disabled
- [ ] `JavaCodeCalculatorV3Test` (existing suite) — should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)