### PR TITLE
fix: grouping parser supports comments after closing parenthesis

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/BooleanBuilder.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/BooleanBuilder.java
@@ -10,6 +10,7 @@ import org.unlaxer.TypedToken;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.elementary.ParenthesesParser;
 import org.unlaxer.tinyexpression.evaluator.javacode.validator.ParserValuesValidator;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.BooleanExpression;
 import org.unlaxer.tinyexpression.parser.BooleanIfExpressionParser;
 import org.unlaxer.tinyexpression.parser.BooleanMatchExpressionParser;
@@ -50,6 +51,7 @@ public class BooleanBuilder implements TokenCodeBuilder {
   static {
     registerHandler(NotBooleanExpressionParser.class, BooleanBuilder::buildNotExpression);
     registerHandler(ParenthesesParser.class, BooleanBuilder::buildParenthesized);
+    registerHandler(JavaStyleParenthesesParser.class, BooleanBuilder::buildJavaStyleParenthesized);
     registerHandler(IsPresentParser.class, BooleanBuilder::buildIsPresent);
     registerHandler(InTimeRangeParser.class, BooleanBuilder::buildInTimeRange);
     registerHandler(InDayTimeRangeParser.class, BooleanBuilder::buildInDayTimeRange);
@@ -134,6 +136,14 @@ public class BooleanBuilder implements TokenCodeBuilder {
   private void buildParenthesized(SimpleJavaCodeBuilder builder, Token token,
       TinyExpressionTokens tinyExpressionTokens) {
     Token parenthesesed = ParenthesesParser.getParenthesesed(token);
+    builder.append("(");
+    BooleanExpressionBuilder.SINGLETON.build(builder, parenthesesed, tinyExpressionTokens);
+    builder.append(")");
+  }
+
+  private void buildJavaStyleParenthesized(SimpleJavaCodeBuilder builder, Token token,
+      TinyExpressionTokens tinyExpressionTokens) {
+    Token parenthesesed = ((JavaStyleParenthesesParser) token.parser).getInnerParserParsed(token);
     builder.append("(");
     BooleanExpressionBuilder.SINGLETON.build(builder, parenthesesed, tinyExpressionTokens);
     builder.append(")");

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/OperatorOperandTreeCreator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/OperatorOperandTreeCreator.java
@@ -111,6 +111,7 @@ import org.unlaxer.tinyexpression.parser.javalang.AnnotationParameterParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationsParser;
 import org.unlaxer.tinyexpression.parser.javalang.BooleanVariableDeclarationParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.javalang.NakedVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.NumberVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.StringVariableDeclarationParser;
@@ -417,13 +418,17 @@ public class OperatorOperandTreeCreator implements TokenReConstructorInterface{
       
       return operator;
       
-    }else if(parser instanceof StringVariableParser|| 
+    }else if(parser instanceof StringVariableParser||
         parser instanceof NakedVariableParser || parser instanceof ExclusiveNakedVariableParser){
-      
+
       return operator;
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
 
     }else if(parser instanceof TrimParser){
@@ -509,16 +514,20 @@ public class OperatorOperandTreeCreator implements TokenReConstructorInterface{
       );
       
     }else if(parser instanceof NumberMatchExpressionParser){
-      
+
       return operator.newCreatesOf(
         apply(NumberMatchExpressionParser.getCaseExpression(operator)),
         apply(NumberMatchExpressionParser.getDefaultExpression(operator))
       );
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof SinParser){
       
       return operator.newCreatesOf(apply(SinParser.getExpression(operator)));
@@ -702,10 +711,14 @@ public class OperatorOperandTreeCreator implements TokenReConstructorInterface{
       return operator;
       
       
+    }else if(parser instanceof JavaStyleParenthesesParser) {
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser) {
 
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof IsPresentParser) {
 
       return operator.newCreatesOf(IsPresentParser.getVariable(operator));

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/StringClauseBuilder.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/StringClauseBuilder.java
@@ -16,6 +16,7 @@ import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.combinator.ChoiceInterface;
 import org.unlaxer.parser.elementary.ParenthesesParser;
 import org.unlaxer.parser.elementary.QuotedParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.evaluator.javacode.SimpleJavaCodeBuilder.Kind;
 import org.unlaxer.tinyexpression.parser.ExpressionInterface;
 import org.unlaxer.tinyexpression.parser.IfExpressionParser;
@@ -60,6 +61,7 @@ public class StringClauseBuilder {
     registerHandler(NakedVariableParser.class, StringClauseBuilder::buildStringVariable);
     registerHandler(StringVariableParser.class, StringClauseBuilder::buildStringVariable);
     registerHandler(ParenthesesParser.class, StringClauseBuilder::buildParentheses);
+    registerHandler(JavaStyleParenthesesParser.class, StringClauseBuilder::buildParentheses);
     registerHandler(TrimParser.class, (self, token, tinyExpressionTokens) ->
         self.buildUnaryStringMethod(token, tinyExpressionTokens, ".trim()"));
     registerHandler(ToUpperCaseParser.class, (self, token, tinyExpressionTokens) ->

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/legacy/LegacyOperatorOperandTreeCreator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/legacy/LegacyOperatorOperandTreeCreator.java
@@ -109,6 +109,7 @@ import org.unlaxer.tinyexpression.parser.javalang.AnnotationParametersParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationsParser;
 import org.unlaxer.tinyexpression.parser.javalang.BooleanVariableDeclarationParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.javalang.NakedVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.NumberVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.StringVariableDeclarationParser;
@@ -406,13 +407,17 @@ public class LegacyOperatorOperandTreeCreator implements TokenReConstructorInter
       
       return operator;
       
-    }else if(parser instanceof StringVariableParser|| 
+    }else if(parser instanceof StringVariableParser||
         parser instanceof NakedVariableParser || parser instanceof ExclusiveNakedVariableParser){
-      
+
       return operator;
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
 
     }else if(parser instanceof TrimParser){
@@ -503,11 +508,15 @@ public class LegacyOperatorOperandTreeCreator implements TokenReConstructorInter
         apply(NumberMatchExpressionParser.getCaseExpression(operator)),
         apply(NumberMatchExpressionParser.getDefaultExpression(operator))
       );
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof SinParser){
       
       return operator.newCreatesOf(apply(SinParser.getExpression(operator)));
@@ -691,10 +700,14 @@ public class LegacyOperatorOperandTreeCreator implements TokenReConstructorInter
       return operator;
       
       
+    }else if(parser instanceof JavaStyleParenthesesParser) {
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser) {
 
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof IsPresentParser) {
 
       return operator.newCreatesOf(IsPresentParser.getVariable(operator));

--- a/src/main/java/org/unlaxer/tinyexpression/parser/AbstractBooleanFactorParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/AbstractBooleanFactorParser.java
@@ -8,7 +8,7 @@ import org.unlaxer.tinyexpression.parser.javatype.*;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.combinator.LazyChoice;
-import org.unlaxer.parser.elementary.ParenthesesParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 
 public abstract class AbstractBooleanFactorParser extends LazyChoice implements BooleanExpression , VariableTypeSelectable{
 
@@ -45,7 +45,7 @@ public abstract class AbstractBooleanFactorParser extends LazyChoice implements 
     parsers.add(BooleanIfExpressionParser.class);
     parsers.add(StrictTypedBooleanMatchExpressionParser.class);
     parsers.add(NotBooleanExpressionParser.class);
-    parsers.add(new ParenthesesParser(Parser.get(BooleanExpressionParser.class)));
+    parsers.add(new JavaStyleParenthesesParser(Parser.get(BooleanExpressionParser.class)));
     parsers.add(IsPresentParser.class);
     parsers.add(BooleanExpressionOfStringParser.class); // <- number == number系より早く評価しないとダメ
     parsers.add(NumberEqualEqualExpressionParser.class);

--- a/src/main/java/org/unlaxer/tinyexpression/parser/AbstractNumberFactorParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/AbstractNumberFactorParser.java
@@ -8,7 +8,7 @@ import org.unlaxer.tinyexpression.parser.javatype.*;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.combinator.LazyChoice;
-import org.unlaxer.parser.elementary.ParenthesesParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.function.CosParser;
 import org.unlaxer.tinyexpression.parser.function.MaxParser;
 import org.unlaxer.tinyexpression.parser.function.MinParser;
@@ -57,7 +57,7 @@ public abstract class AbstractNumberFactorParser extends LazyChoice implements N
         NumberExpressionParser.class:
           StrictTypedNumberExpressionParser.class;
     
-    parsers.add(new ParenthesesParser(
+    parsers.add(new JavaStyleParenthesesParser(
         Parser.newInstance(
             expresionParserClazz)
         )

--- a/src/main/java/org/unlaxer/tinyexpression/parser/AbstractStringFactorParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/AbstractStringFactorParser.java
@@ -8,7 +8,7 @@ import org.unlaxer.tinyexpression.parser.javatype.*;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.combinator.LazyChoice;
-import org.unlaxer.parser.elementary.ParenthesesParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 
 public abstract class AbstractStringFactorParser extends LazyChoice implements StringExpression , VariableTypeSelectable{
 	
@@ -33,7 +33,7 @@ public abstract class AbstractStringFactorParser extends LazyChoice implements S
     if(withNakedVariable) {
       parsers.add(ExclusiveNakedVariableParser.class);
     }
-    parsers.add(new ParenthesesParser(Parser.get(NESTED)));
+    parsers.add(new JavaStyleParenthesesParser(Parser.get(NESTED)));
     parsers.add(TrimParser.class);
     parsers.add(ToUpperCaseParser.class);
     parsers.add(ToLowerCaseParser.class);

--- a/src/main/java/org/unlaxer/tinyexpression/parser/javalang/JavaStyleParenthesesParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/javalang/JavaStyleParenthesesParser.java
@@ -6,7 +6,6 @@ import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.ascii.LeftParenthesisParser;
 import org.unlaxer.parser.ascii.RightParenthesisParser;
-import org.unlaxer.parser.elementary.ParenthesesParser;
 import org.unlaxer.util.annotation.TokenExtractor;
 
 public class JavaStyleParenthesesParser extends JavaStyleDelimitedLazyChain {
@@ -37,14 +36,14 @@ public class JavaStyleParenthesesParser extends JavaStyleDelimitedLazyChain {
   
   @TokenExtractor
   public static Token getParenthesesed(Token parenthesesed ){
-    if(false == parenthesesed.parser instanceof ParenthesesParser){
-      throw new IllegalArgumentException("this token did not generate from " + 
-        ParenthesesParser.class.getName());
+    if(false == parenthesesed.parser instanceof JavaStyleParenthesesParser){
+      throw new IllegalArgumentException("this token did not generate from " +
+        JavaStyleParenthesesParser.class.getName());
     }
-    Parser contentsParser = JavaStyleParenthesesParser.class.cast(parenthesesed.parser).inner;
+    Parser contentsParser = JavaStyleParenthesesParser.class.cast(parenthesesed.parser).getParenthesesedParser();
     return parenthesesed.getChildWithParser(parser -> parser.equals(contentsParser));
   }
-  
+
   public Parser getParenthesesedParser(){
     return inner == null ? Parser.get(clazz) : inner;
   }
@@ -62,7 +61,6 @@ public class JavaStyleParenthesesParser extends JavaStyleDelimitedLazyChain {
 
   @TokenExtractor
   public Token getInnerParserParsed(Token thisParserParsed) {
-//    return thisParserParsed.filteredChildren.get(1);
-    return thisParserParsed.getChildWithParser(parser->parser.equals(inner));
+    return thisParserParsed.getChildWithParser(parser->parser.equals(getParenthesesedParser()));
   }
 }

--- a/src/test/java/org/unlaxer/tinyexpression/parser/BooleanExpressionParserTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/parser/BooleanExpressionParserTest.java
@@ -13,14 +13,26 @@ public class BooleanExpressionParserTest extends ParserTestBase{
 
   @Test
   public void test() {
-    
+
     setLevel(OutputLevel.detail);
     BooleanExpressionParser parser = new BooleanExpressionParser();
-    
+
     testAllMatch(parser, "true");
     testAllMatch(parser, "true | false ");
     testAllMatch(parser, "true & $foo == 1");
     testAllMatch(parser, "$hour>0 & $hour<5");
+  }
+
+  @Test
+  public void testGroupingFollowedByComment() {
+    // Regression test for issue #14:
+    // comment after grouping like (a & b) // comment should not cause a parse error
+    BooleanExpressionParser parser = new BooleanExpressionParser();
+
+    testAllMatch(parser, "($foo == 1 & $bar == 2)");
+    testAllMatch(parser, "($foo == 1 & $bar == 2) // comment");
+    testAllMatch(parser, "($foo == 1 & $bar == 2) /* block comment */");
+    testAllMatch(parser, "($foo == 1) | ($bar == 2) // trailing comment");
   }
 
 }


### PR DESCRIPTION
Closes #14

## 問題

`(a & b)` のようなグルーピングの直後にコメントを入れると、実行時に `failed to parse formulaInfo` エラーとなっていた。

## 原因

`AbstractBooleanFactorParser`（および `AbstractNumberFactorParser`, `AbstractStringFactorParser`）が使用していた `ParenthesesParser` は `WhiteSpaceDelimitedLazyChain` を継承しており、要素間の区切りに `SpaceDelimitor`（空白のみ）を使用していた。そのため、コメントをparseできずエラーとなっていた。

## 修正

- `AbstractBooleanFactorParser`, `AbstractNumberFactorParser`, `AbstractStringFactorParser` が使用するパーサを `ParenthesesParser` から `JavaStyleParenthesesParser` に変更
  - `JavaStyleParenthesesParser` は `JavaStyleDelimitedLazyChain` を継承し、`JavaStyleDelimitor`（スペース・ブロックコメント・CPPコメントを区切りとして認識）を使用
- 評価器（`BooleanBuilder`, `OperatorOperandTreeCreator`, `StringClauseBuilder`, `LegacyOperatorOperandTreeCreator`）が `JavaStyleParenthesesParser` を処理できるよう更新
- `JavaStyleParenthesesParser.getParenthesesed` の `instanceof ParenthesesParser` チェックのバグも合わせて修正

## テスト

`BooleanExpressionParserTest#testGroupingFollowedByComment` を追加:
- `(a & b) // comment` 形式
- `(a & b) /* block comment */` 形式

🤖 Generated with [Claude Code](https://claude.com/claude-code)