### PR TITLE
fix: TernaryExpression + AstEvaluatorGeneratedValuePath test failures (closes #6)

### DIFF
--- a/docs/railroad/TinyExpressionP4_AbsFunction.svg
+++ b/docs/railroad/TinyExpressionP4_AbsFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AbsFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2023868543">
-<g id="550358665">
+<g id="169156544">
+<g id="1318322346">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'abs'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="685179480">
+<g id="1165510562">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="334642514">
+<g id="1194558942">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="920052138">
+<g id="1693106855">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_AddOp.svg
+++ b/docs/railroad/TinyExpressionP4_AddOp.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AddOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1192116328">
-<g id="926395681">
+<g id="1850994478">
+<g id="2091812815">
 <rect x="56" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="62" text-anchor="middle" class="terminal-text">'+'</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="97" y1="58" x2="97" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="97" y1="58" x2="113" y2="58" class="rail"/>
-<g id="1380634323">
+<g id="544666991">
 <rect x="56" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="100" text-anchor="middle" class="terminal-text">'-'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_Annotation.svg
+++ b/docs/railroad/TinyExpressionP4_Annotation.svg
@@ -14,27 +14,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Annotation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="618876592">
-<g id="697966650">
+<g id="1326634265">
+<g id="680733317">
 <rect x="40" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="80" text-anchor="middle" class="terminal-text">'@'</text>
 </g>
 <line x1="81" y1="76" x2="101" y2="76" class="rail"/>
 <polygon points="88,73 94,76 88,79" class="arrow"/>
-<g id="1283777700">
+<g id="790202390">
 <rect x="101" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="146" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="191" y1="76" x2="211" y2="76" class="rail"/>
 <polygon points="198,73 204,76 198,79" class="arrow"/>
-<g id="978659050">
+<g id="981294197">
 <rect x="211" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="231" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="252" y1="76" x2="272" y2="76" class="rail"/>
 <polygon points="259,73 265,76 259,79" class="arrow"/>
-<g id="1549279781">
-<g id="616258936">
+<g id="2087109313">
+<g id="1292902116">
 <rect x="288" y="62" width="160" height="28" class="nonterminal-box"/>
 <text x="368" y="80" text-anchor="middle" class="nonterminal-text">AnnotationParameters</text>
 </g>
@@ -48,7 +48,7 @@
 </g>
 <line x1="464" y1="76" x2="484" y2="76" class="rail"/>
 <polygon points="471,73 477,76 471,79" class="arrow"/>
-<g id="923950286">
+<g id="534555747">
 <rect x="484" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="504" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_AnnotationParameter.svg
+++ b/docs/railroad/TinyExpressionP4_AnnotationParameter.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AnnotationParameter</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2025946628">
-<g id="1096807527">
+<g id="1291745917">
+<g id="2079748071">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="532534230">
+<g id="813604803">
 <rect x="150" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="terminal-text">'='</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="1522364886">
+<g id="569769615">
 <rect x="211" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_AnnotationParameters.svg
+++ b/docs/railroad/TinyExpressionP4_AnnotationParameters.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AnnotationParameters</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1674064591">
-<g id="1523423177">
+<g id="1951610538">
+<g id="45618465">
 <rect x="40" y="44" width="153" height="28" class="nonterminal-box"/>
 <text x="116" y="62" text-anchor="middle" class="nonterminal-text">AnnotationParameter</text>
 </g>
 <line x1="193" y1="58" x2="213" y2="58" class="rail"/>
 <polygon points="200,55 206,58 200,61" class="arrow"/>
-<g id="1780870147">
-<g id="1558207369">
-<g id="1201262527">
+<g id="704056766">
+<g id="1805917430">
+<g id="1216528253">
 <rect x="229" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="249" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="270" y1="82" x2="290" y2="82" class="rail"/>
 <polygon points="277,79 283,82 277,85" class="arrow"/>
-<g id="1657278382">
+<g id="843558330">
 <rect x="290" y="68" width="153" height="28" class="nonterminal-box"/>
 <text x="366" y="86" text-anchor="middle" class="nonterminal-text">AnnotationParameter</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ArgumentExpression.svg
+++ b/docs/railroad/TinyExpressionP4_ArgumentExpression.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ArgumentExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="107034272">
-<g id="1050862558">
+<g id="591234965">
+<g id="1669944859">
 <rect x="56" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="118" y="62" text-anchor="middle" class="nonterminal-text">ArgumentTernary</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="181" y1="58" x2="181" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="181" y1="58" x2="197" y2="58" class="rail"/>
-<g id="589257109">
+<g id="1969401156">
 <rect x="73" y="82" width="90" height="28" class="nonterminal-box"/>
 <text x="118" y="100" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ArgumentTernary.svg
+++ b/docs/railroad/TinyExpressionP4_ArgumentTernary.svg
@@ -14,32 +14,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ArgumentTernary</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1263455638">
-<g id="1637594851">
+<g id="1465816250">
+<g id="818217691">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="206592386">
+<g id="2045263155">
 <rect x="199" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="219" y="62" text-anchor="middle" class="terminal-text">'?'</text>
 </g>
 <line x1="240" y1="58" x2="260" y2="58" class="rail"/>
 <polygon points="247,55 253,58 247,61" class="arrow"/>
-<g id="455988879">
+<g id="1979196257">
 <rect x="260" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="305" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="350" y1="58" x2="370" y2="58" class="rail"/>
 <polygon points="357,55 363,58 357,61" class="arrow"/>
-<g id="2035064210">
+<g id="2007771684">
 <rect x="370" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="390" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="411" y1="58" x2="431" y2="58" class="rail"/>
 <polygon points="418,55 424,58 418,61" class="arrow"/>
-<g id="1163661558">
+<g id="1877421520">
 <rect x="431" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="476" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_Arguments.svg
+++ b/docs/railroad/TinyExpressionP4_Arguments.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Arguments</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1081011059">
-<g id="1006528903">
+<g id="710142504">
+<g id="6630412">
 <rect x="40" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="113" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="186" y1="58" x2="206" y2="58" class="rail"/>
 <polygon points="193,55 199,58 193,61" class="arrow"/>
-<g id="205582775">
-<g id="1153047286">
-<g id="317444405">
+<g id="796882273">
+<g id="106118379">
+<g id="695573397">
 <rect x="222" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="242" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="263" y1="82" x2="283" y2="82" class="rail"/>
 <polygon points="270,79 276,82 270,85" class="arrow"/>
-<g id="1264709900">
+<g id="1226644338">
 <rect x="283" y="68" width="146" height="28" class="nonterminal-box"/>
 <text x="356" y="86" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanAndExpression.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanAndExpression.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanAndExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="947180427">
-<g id="213642464">
+<g id="854499140">
+<g id="1018455071">
 <rect x="40" y="44" width="160" height="28" class="nonterminal-box"/>
 <text x="120" y="62" text-anchor="middle" class="nonterminal-text">BooleanXorExpression</text>
 </g>
 <line x1="200" y1="58" x2="220" y2="58" class="rail"/>
 <polygon points="207,55 213,58 207,61" class="arrow"/>
-<g id="1359741121">
-<g id="42147997">
-<g id="1259618483">
+<g id="1621204506">
+<g id="2133494140">
+<g id="681529418">
 <rect x="236" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="256" y="86" text-anchor="middle" class="terminal-text">'&amp;'</text>
 </g>
 <line x1="277" y1="82" x2="297" y2="82" class="rail"/>
 <polygon points="284,79 290,82 284,85" class="arrow"/>
-<g id="1835667281">
+<g id="1110417977">
 <rect x="297" y="68" width="160" height="28" class="nonterminal-box"/>
 <text x="377" y="86" text-anchor="middle" class="nonterminal-text">BooleanXorExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanCase.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanCase.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1632177451">
-<g id="514770737">
+<g id="1765054694">
+<g id="480577395">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="1025981785">
+<g id="1278268960">
 <rect x="199" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="223" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="337936520">
+<g id="1328872207">
 <rect x="267" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="333" y="62" text-anchor="middle" class="nonterminal-text">BooleanCaseValue</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanCaseValue.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanCaseValue.svg
@@ -14,7 +14,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanCaseValue</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="732214539">
+<g id="460926014">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanComparable.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanComparable.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanComparable</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1009091259">
-<g id="310239569">
+<g id="433034875">
+<g id="2037396618">
 <rect x="131" y="44" width="111" height="28" class="nonterminal-box"/>
 <text x="186" y="62" text-anchor="middle" class="nonterminal-text">NotExpression</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="242" y1="58" x2="317" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="317" y1="58" x2="333" y2="58" class="rail"/>
-<g id="1298828197">
+<g id="1467151875">
 <rect x="99" y="82" width="174" height="28" class="nonterminal-box"/>
 <text x="186" y="100" text-anchor="middle" class="nonterminal-text">BooleanMatchExpression</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M317,96 Q325,96 325,88" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="232530967">
+<g id="1829513200">
 <rect x="89" y="120" width="195" height="28" class="nonterminal-box"/>
 <text x="186" y="138" text-anchor="middle" class="nonterminal-text">ExternalBooleanInvocation</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M317,134 Q325,134 325,126" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="452848978">
+<g id="1380494223">
 <rect x="148" y="158" width="76" height="28" class="nonterminal-box"/>
 <text x="186" y="176" text-anchor="middle" class="nonterminal-text">InMethod</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M317,172 Q325,172 325,164" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1744302133">
+<g id="711201064">
 <rect x="110" y="196" width="153" height="28" class="nonterminal-box"/>
 <text x="186" y="214" text-anchor="middle" class="nonterminal-text">StartsWithDotMethod</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M317,210 Q325,210 325,202" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="2119788749">
+<g id="1793468553">
 <rect x="117" y="234" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="252" text-anchor="middle" class="nonterminal-text">EndsWithDotMethod</text>
 </g>
@@ -73,7 +73,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M317,248 Q325,248 325,240" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="315168653">
+<g id="1717150082">
 <rect x="117" y="272" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="290" text-anchor="middle" class="nonterminal-text">ContainsDotMethod</text>
 </g>
@@ -83,7 +83,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M317,286 Q325,286 325,278" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1739321339">
+<g id="1901750805">
 <rect x="113" y="310" width="146" height="28" class="nonterminal-box"/>
 <text x="186" y="328" text-anchor="middle" class="nonterminal-text">StartsWithFunction</text>
 </g>
@@ -93,7 +93,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M317,324 Q325,324 325,316" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1057344867">
+<g id="2067650631">
 <rect x="120" y="348" width="132" height="28" class="nonterminal-box"/>
 <text x="186" y="366" text-anchor="middle" class="nonterminal-text">EndsWithFunction</text>
 </g>
@@ -103,7 +103,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M317,362 Q325,362 325,354" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="170902862">
+<g id="541328841">
 <rect x="120" y="386" width="132" height="28" class="nonterminal-box"/>
 <text x="186" y="404" text-anchor="middle" class="nonterminal-text">ContainsFunction</text>
 </g>
@@ -113,7 +113,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M317,400 Q325,400 325,392" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1350622969">
+<g id="196797938">
 <rect x="117" y="424" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="442" text-anchor="middle" class="nonterminal-text">IsPresentFunction</text>
 </g>
@@ -123,7 +123,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M317,438 Q325,438 325,430" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1751922469">
+<g id="689060946">
 <rect x="110" y="462" width="153" height="28" class="nonterminal-box"/>
 <text x="186" y="480" text-anchor="middle" class="nonterminal-text">InTimeRangeFunction</text>
 </g>
@@ -133,7 +133,7 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M317,476 Q325,476 325,468" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="2039710110">
+<g id="1022895831">
 <rect x="99" y="500" width="174" height="28" class="nonterminal-box"/>
 <text x="186" y="518" text-anchor="middle" class="nonterminal-text">InDayTimeRangeFunction</text>
 </g>
@@ -143,7 +143,7 @@
 <path d="M48,506 Q48,514 56,514" class="rail" fill="none"/>
 <path d="M317,514 Q325,514 325,506" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="224538199">
+<g id="1016202956">
 <rect x="155" y="538" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="556" text-anchor="middle" class="terminal-text">'true'</text>
 </g>
@@ -153,7 +153,7 @@
 <path d="M48,544 Q48,552 56,552" class="rail" fill="none"/>
 <path d="M317,552 Q325,552 325,544" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1531137556">
+<g id="1616634329">
 <rect x="152" y="576" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="594" text-anchor="middle" class="terminal-text">'false'</text>
 </g>
@@ -163,7 +163,7 @@
 <path d="M48,582 Q48,590 56,590" class="rail" fill="none"/>
 <path d="M317,590 Q325,590 325,582" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1386188614">
+<g id="1477685548">
 <rect x="138" y="614" width="97" height="28" class="nonterminal-box"/>
 <text x="186" y="632" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -173,7 +173,7 @@
 <path d="M48,620 Q48,628 56,628" class="rail" fill="none"/>
 <path d="M317,628 Q325,628 325,620" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="929393658">
+<g id="622918247">
 <rect x="120" y="652" width="132" height="28" class="nonterminal-box"/>
 <text x="186" y="670" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -183,20 +183,20 @@
 <path d="M48,658 Q48,666 56,666" class="rail" fill="none"/>
 <path d="M317,666 Q325,666 325,658" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1484193073">
-<g id="728361943">
+<g id="1372332895">
+<g id="153631849">
 <rect x="56" y="690" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="708" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="97" y1="704" x2="117" y2="704" class="rail"/>
 <polygon points="104,701 110,704 104,707" class="arrow"/>
-<g id="1780167488">
+<g id="918704572">
 <rect x="117" y="690" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="708" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="256" y1="704" x2="276" y2="704" class="rail"/>
 <polygon points="263,701 269,704 263,707" class="arrow"/>
-<g id="1146119418">
+<g id="1931287705">
 <rect x="276" y="690" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="296" y="708" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanDefaultCase.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanDefaultCase.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanDefaultCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="342258642">
-<g id="162974076">
+<g id="854585787">
+<g id="1570673708">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'default'</text>
 </g>
 <line x1="123" y1="58" x2="143" y2="58" class="rail"/>
 <polygon points="130,55 136,58 130,61" class="arrow"/>
-<g id="234873062">
+<g id="391497833">
 <rect x="143" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="1039073553">
+<g id="2144445711">
 <rect x="211" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="277" y="62" text-anchor="middle" class="nonterminal-text">BooleanCaseValue</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanEqualityExpression.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanEqualityExpression.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanEqualityExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="930572475">
-<g id="253175628">
+<g id="1941534747">
+<g id="1034189647">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="1210574304">
+<g id="650527158">
 <rect x="199" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="244" y="62" text-anchor="middle" class="nonterminal-text">EqualityOp</text>
 </g>
 <line x1="289" y1="58" x2="309" y2="58" class="rail"/>
 <polygon points="296,55 302,58 296,61" class="arrow"/>
-<g id="668403360">
+<g id="371214570">
 <rect x="309" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="378" y="62" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanExpression.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanExpression.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1868569813">
-<g id="43303708">
+<g id="530858907">
+<g id="1218149557">
 <rect x="40" y="44" width="160" height="28" class="nonterminal-box"/>
 <text x="120" y="62" text-anchor="middle" class="nonterminal-text">BooleanAndExpression</text>
 </g>
 <line x1="200" y1="58" x2="220" y2="58" class="rail"/>
 <polygon points="207,55 213,58 207,61" class="arrow"/>
-<g id="1168932494">
-<g id="1627708817">
-<g id="101031010">
+<g id="1223972317">
+<g id="1528423647">
+<g id="1531025600">
 <rect x="236" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="256" y="86" text-anchor="middle" class="terminal-text">'|'</text>
 </g>
 <line x1="277" y1="82" x2="297" y2="82" class="rail"/>
 <polygon points="284,79 290,82 284,85" class="arrow"/>
-<g id="1645225244">
+<g id="1724432247">
 <rect x="297" y="68" width="160" height="28" class="nonterminal-box"/>
 <text x="377" y="86" text-anchor="middle" class="nonterminal-text">BooleanAndExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanFactor.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanFactor.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanFactor</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="83835428">
-<g id="32248926">
+<g id="1888557446">
+<g id="1834556192">
 <rect x="59" y="44" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="nonterminal-text">BooleanEqualityExpression</text>
 </g>
@@ -23,17 +23,17 @@
 <line x1="254" y1="58" x2="258" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="258" y1="58" x2="274" y2="58" class="rail"/>
-<g id="1989409126">
-<rect x="87" y="82" width="139" height="28" class="nonterminal-box"/>
-<text x="156" y="100" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
+<g id="2038836428">
+<rect x="77" y="82" width="160" height="28" class="nonterminal-box"/>
+<text x="157" y="100" text-anchor="middle" class="nonterminal-text">ComparisonExpression</text>
 </g>
-<line x1="56" y1="96" x2="87" y2="96" class="rail"/>
-<line x1="226" y1="96" x2="258" y2="96" class="rail"/>
+<line x1="56" y1="96" x2="77" y2="96" class="rail"/>
+<line x1="237" y1="96" x2="258" y2="96" class="rail"/>
 <path d="M40,58 Q48,58 48,66" class="rail" fill="none"/>
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M258,96 Q266,96 266,88" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="1777210130">
+<g id="1844796430">
 <rect x="56" y="120" width="202" height="28" class="nonterminal-box"/>
 <text x="157" y="138" text-anchor="middle" class="nonterminal-text">StringComparisonExpression</text>
 </g>
@@ -43,12 +43,12 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M258,134 Q266,134 266,126" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="1708166180">
-<rect x="77" y="158" width="160" height="28" class="nonterminal-box"/>
-<text x="157" y="176" text-anchor="middle" class="nonterminal-text">ComparisonExpression</text>
+<g id="1437894667">
+<rect x="87" y="158" width="139" height="28" class="nonterminal-box"/>
+<text x="156" y="176" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
 </g>
-<line x1="56" y1="172" x2="77" y2="172" class="rail"/>
-<line x1="237" y1="172" x2="258" y2="172" class="rail"/>
+<line x1="56" y1="172" x2="87" y2="172" class="rail"/>
+<line x1="226" y1="172" x2="258" y2="172" class="rail"/>
 <path d="M40,58 Q48,58 48,66" class="rail" fill="none"/>
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M258,172 Q266,172 266,164" class="rail" fill="none"/>

--- a/docs/railroad/TinyExpressionP4_BooleanMatchExpression.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanMatchExpression.svg
@@ -14,34 +14,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanMatchExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2032244528">
-<g id="582357138">
+<g id="612386003">
+<g id="1959968072">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'match'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1410058768">
+<g id="1164718424">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1185068069">
+<g id="1217277484">
 <rect x="190" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="238" y="62" text-anchor="middle" class="nonterminal-text">BooleanCase</text>
 </g>
 <line x1="287" y1="58" x2="307" y2="58" class="rail"/>
 <polygon points="294,55 300,58 294,61" class="arrow"/>
-<g id="971277870">
-<g id="1790186689">
-<g id="1925559757">
+<g id="123729813">
+<g id="1041842484">
+<g id="2072157955">
 <rect x="323" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="343" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="364" y1="82" x2="384" y2="82" class="rail"/>
 <polygon points="371,79 377,82 371,85" class="arrow"/>
-<g id="1625622919">
+<g id="450581958">
 <rect x="384" y="68" width="97" height="28" class="nonterminal-box"/>
 <text x="432" y="86" text-anchor="middle" class="nonterminal-text">BooleanCase</text>
 </g>
@@ -62,19 +62,19 @@
 </g>
 <line x1="497" y1="58" x2="517" y2="58" class="rail"/>
 <polygon points="504,55 510,58 504,61" class="arrow"/>
-<g id="1724921602">
+<g id="1749687034">
 <rect x="517" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="537" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="558" y1="58" x2="578" y2="58" class="rail"/>
 <polygon points="565,55 571,58 565,61" class="arrow"/>
-<g id="775005038">
+<g id="687806288">
 <rect x="578" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="651" y="62" text-anchor="middle" class="nonterminal-text">BooleanDefaultCase</text>
 </g>
 <line x1="724" y1="58" x2="744" y2="58" class="rail"/>
 <polygon points="731,55 737,58 731,61" class="arrow"/>
-<g id="1693034613">
+<g id="1545331610">
 <rect x="744" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="764" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanMethodDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanMethodDeclaration.svg
@@ -14,27 +14,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="743124741">
-<g id="513146964">
+<g id="1597480639">
+<g id="1196344165">
 <rect x="40" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="80" text-anchor="middle" class="nonterminal-text">BooleanReturnType</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="978962060">
+<g id="1977352996">
 <rect x="199" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="244" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="289" y1="76" x2="309" y2="76" class="rail"/>
 <polygon points="296,73 302,76 296,79" class="arrow"/>
-<g id="1587299554">
+<g id="1843485638">
 <rect x="309" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="329" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="350" y1="76" x2="370" y2="76" class="rail"/>
 <polygon points="357,73 363,76 357,79" class="arrow"/>
-<g id="2000959143">
-<g id="1501432188">
+<g id="1144353508">
+<g id="1968296640">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -48,25 +48,25 @@
 </g>
 <line x1="534" y1="76" x2="554" y2="76" class="rail"/>
 <polygon points="541,73 547,76 541,79" class="arrow"/>
-<g id="64873317">
+<g id="1365609573">
 <rect x="554" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="574" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="595" y1="76" x2="615" y2="76" class="rail"/>
 <polygon points="602,73 608,76 602,79" class="arrow"/>
-<g id="1071254696">
+<g id="910021348">
 <rect x="615" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="635" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="656" y1="76" x2="676" y2="76" class="rail"/>
 <polygon points="663,73 669,76 663,79" class="arrow"/>
-<g id="373737414">
+<g id="1300349233">
 <rect x="676" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="745" y="80" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="815" y1="76" x2="835" y2="76" class="rail"/>
 <polygon points="822,73 828,76 822,79" class="arrow"/>
-<g id="1080113831">
+<g id="575420471">
 <rect x="835" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="855" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanReturnType.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanReturnType.svg
@@ -14,7 +14,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1739923983">
+<g id="379698799">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'boolean'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanSetter.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanSetter.svg
@@ -14,28 +14,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="2104839723">
-<g id="347364011">
+<g id="1346708350">
+<g id="1323315555">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="1192312520">
-<g id="471564068">
-<g id="139092844">
+<g id="1192506766">
+<g id="1707189998">
+<g id="825391264">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="1343490306">
+<g id="922000157">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="709626308">
+<g id="719712760">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -50,7 +50,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="935158577">
+<g id="1437233666">
 <rect x="386" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="455" y="80" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanTypeHint.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanTypeHint.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1082188311">
-<g id="1228134151">
-<g id="1422199612">
+<g id="2026014007">
+<g id="208149928">
+<g id="2102356381">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -30,7 +30,7 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1900913535">
+<g id="1201070432">
 <rect x="140" y="62" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="181" y="80" text-anchor="middle" class="terminal-text">'boolean'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanVariableDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanVariableDeclaration.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="587668039">
-<g id="396312870">
-<g id="95686820">
+<g id="1852377273">
+<g id="1338086756">
+<g id="922641479">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -24,7 +24,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="925044710">
+<g id="430357618">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -37,20 +37,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1800005591">
+<g id="1753490722">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="1144691047">
+<g id="1148010860">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="138505656">
-<g id="700540599">
+<g id="1193111474">
+<g id="121931312">
 <rect x="369" y="62" width="125" height="28" class="nonterminal-box"/>
 <text x="431" y="80" text-anchor="middle" class="nonterminal-text">BooleanTypeHint</text>
 </g>
@@ -64,8 +64,8 @@
 </g>
 <line x1="510" y1="76" x2="530" y2="76" class="rail"/>
 <polygon points="517,73 523,76 517,79" class="arrow"/>
-<g id="1014169964">
-<g id="747787320">
+<g id="540129748">
+<g id="251260742">
 <rect x="546" y="62" width="111" height="28" class="nonterminal-box"/>
 <text x="601" y="80" text-anchor="middle" class="nonterminal-text">BooleanSetter</text>
 </g>
@@ -79,13 +79,13 @@
 </g>
 <line x1="673" y1="76" x2="693" y2="76" class="rail"/>
 <polygon points="680,73 686,76 680,79" class="arrow"/>
-<g id="505752715">
+<g id="65523428">
 <rect x="693" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="741" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="790" y1="76" x2="810" y2="76" class="rail"/>
 <polygon points="797,73 803,76 797,79" class="arrow"/>
-<g id="495631962">
+<g id="799752661">
 <rect x="810" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="830" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_BooleanXorExpression.svg
+++ b/docs/railroad/TinyExpressionP4_BooleanXorExpression.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanXorExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1217539683">
-<g id="98128723">
+<g id="2008427861">
+<g id="233823562">
 <rect x="40" y="44" width="111" height="28" class="nonterminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="nonterminal-text">BooleanFactor</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="2114250218">
-<g id="831023939">
-<g id="516234429">
+<g id="2143085716">
+<g id="206204378">
+<g id="640009442">
 <rect x="187" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="207" y="86" text-anchor="middle" class="terminal-text">'^'</text>
 </g>
 <line x1="228" y1="82" x2="248" y2="82" class="rail"/>
 <polygon points="235,79 241,82 235,85" class="arrow"/>
-<g id="796790188">
+<g id="1251532658">
 <rect x="248" y="68" width="111" height="28" class="nonterminal-box"/>
 <text x="303" y="86" text-anchor="middle" class="nonterminal-text">BooleanFactor</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_CeilFunction.svg
+++ b/docs/railroad/TinyExpressionP4_CeilFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CeilFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1038292916">
-<g id="1252697321">
+<g id="555655770">
+<g id="779320189">
 <rect x="40" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="71" y="62" text-anchor="middle" class="terminal-text">'ceil'</text>
 </g>
 <line x1="102" y1="58" x2="122" y2="58" class="rail"/>
 <polygon points="109,55 115,58 109,61" class="arrow"/>
-<g id="28269765">
+<g id="696239976">
 <rect x="122" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="142" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="163" y1="58" x2="183" y2="58" class="rail"/>
 <polygon points="170,55 176,58 170,61" class="arrow"/>
-<g id="437766055">
+<g id="1125464208">
 <rect x="183" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="577860351">
+<g id="335776564">
 <rect x="349" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="369" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ClassName.svg
+++ b/docs/railroad/TinyExpressionP4_ClassName.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ClassName</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="277762388">
-<g id="2107009673">
+<g id="1326983763">
+<g id="1235903355">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="1166050455">
-<g id="185361757">
-<g id="279490165">
+<g id="779331271">
+<g id="886614684">
+<g id="1741736793">
 <rect x="166" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="86" text-anchor="middle" class="terminal-text">'.'</text>
 </g>
 <line x1="207" y1="82" x2="227" y2="82" class="rail"/>
 <polygon points="214,79 220,82 214,85" class="arrow"/>
-<g id="1261314522">
+<g id="652574998">
 <rect x="227" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="272" y="86" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_CodeBlock.svg
+++ b/docs/railroad/TinyExpressionP4_CodeBlock.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CodeBlock</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1102118476">
-<g id="526337349">
+<g id="1606285184">
+<g id="581961862">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">CODE_START</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="4976130">
+<g id="540646640">
 <rect x="150" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="nonterminal-text">CODE_BODY</text>
 </g>
 <line x1="233" y1="58" x2="253" y2="58" class="rail"/>
 <polygon points="240,55 246,58 240,61" class="arrow"/>
-<g id="1813562815">
+<g id="2053401217">
 <rect x="253" y="44" width="76" height="28" class="nonterminal-box"/>
 <text x="291" y="62" text-anchor="middle" class="nonterminal-text">CODE_END</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_CompareOp.svg
+++ b/docs/railroad/TinyExpressionP4_CompareOp.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CompareOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1266904085">
-<g id="942026516">
+<g id="391267417">
+<g id="901875742">
 <rect x="56" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="62" text-anchor="middle" class="terminal-text">'=='</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="104" y1="58" x2="104" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="104" y1="58" x2="120" y2="58" class="rail"/>
-<g id="2103250233">
+<g id="1081114086">
 <rect x="56" y="82" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="100" text-anchor="middle" class="terminal-text">'!='</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M104,96 Q112,96 112,88" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="823796094">
+<g id="904649947">
 <rect x="56" y="120" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="138" text-anchor="middle" class="terminal-text">'&lt;='</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M104,134 Q112,134 112,126" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="923048089">
+<g id="105938682">
 <rect x="56" y="158" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="176" text-anchor="middle" class="terminal-text">'&gt;='</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M104,172 Q112,172 112,164" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="1054040034">
+<g id="1063819094">
 <rect x="59" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="79" y="214" text-anchor="middle" class="terminal-text">'&lt;'</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M104,210 Q112,210 112,202" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="737323460">
+<g id="2092188176">
 <rect x="59" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="79" y="252" text-anchor="middle" class="terminal-text">'&gt;'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ComparisonExpression.svg
+++ b/docs/railroad/TinyExpressionP4_ComparisonExpression.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ComparisonExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="526593907">
-<g id="1785311594">
+<g id="1517108384">
+<g id="1935901711">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="2112297762">
+<g id="222240615">
 <rect x="192" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="233" y="62" text-anchor="middle" class="nonterminal-text">CompareOp</text>
 </g>
 <line x1="275" y1="58" x2="295" y2="58" class="rail"/>
 <polygon points="282,55 288,58 282,61" class="arrow"/>
-<g id="550344916">
+<g id="1582659428">
 <rect x="295" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="361" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ContainsDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_ContainsDotMethod.svg
@@ -14,32 +14,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ContainsDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="479713637">
-<g id="647096144">
+<g id="443482771">
+<g id="217801159">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="989853684">
+<g id="832315779">
 <rect x="157" y="44" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="205" y="62" text-anchor="middle" class="terminal-text">'.contains'</text>
 </g>
 <line x1="254" y1="58" x2="274" y2="58" class="rail"/>
 <polygon points="261,55 267,58 261,61" class="arrow"/>
-<g id="319969687">
+<g id="1842567277">
 <rect x="274" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="294" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="1888487361">
+<g id="487398739">
 <rect x="335" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="467" y1="58" x2="487" y2="58" class="rail"/>
 <polygon points="474,55 480,58 474,61" class="arrow"/>
-<g id="1494402532">
+<g id="1244635756">
 <rect x="487" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="507" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ContainsFunction.svg
+++ b/docs/railroad/TinyExpressionP4_ContainsFunction.svg
@@ -14,38 +14,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ContainsFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1753690872">
-<g id="1247370886">
+<g id="612485105">
+<g id="1773626628">
 <rect x="40" y="44" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="terminal-text">'contains'</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="146069825">
+<g id="513680667">
 <rect x="150" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="1680444610">
+<g id="223130485">
 <rect x="211" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="277" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="343" y1="58" x2="363" y2="58" class="rail"/>
 <polygon points="350,55 356,58 350,61" class="arrow"/>
-<g id="1855817175">
+<g id="1898613222">
 <rect x="363" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="383" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="404" y1="58" x2="424" y2="58" class="rail"/>
 <polygon points="411,55 417,58 411,61" class="arrow"/>
-<g id="1857051628">
+<g id="602361218">
 <rect x="424" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="490" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="556" y1="58" x2="576" y2="58" class="rail"/>
 <polygon points="563,55 569,58 563,61" class="arrow"/>
-<g id="1080097194">
+<g id="1279136280">
 <rect x="576" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="596" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_CosFunction.svg
+++ b/docs/railroad/TinyExpressionP4_CosFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CosFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="72248965">
-<g id="257474353">
+<g id="804092032">
+<g id="68695025">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'cos'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1922787909">
+<g id="623247348">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="485941391">
+<g id="1045002560">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1319493975">
+<g id="1781488015">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_DayOfWeek.svg
+++ b/docs/railroad/TinyExpressionP4_DayOfWeek.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">DayOfWeek</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1356601834">
-<g id="1771871885">
+<g id="44840797">
+<g id="1330759884">
 <rect x="66" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="62" text-anchor="middle" class="terminal-text">'MONDAY'</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="142" y1="58" x2="153" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="153" y1="58" x2="169" y2="58" class="rail"/>
-<g id="1850559365">
+<g id="1967669096">
 <rect x="63" y="82" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="100" text-anchor="middle" class="terminal-text">'TUESDAY'</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M153,96 Q161,96 161,88" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="204863426">
+<g id="2018325108">
 <rect x="56" y="120" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="138" text-anchor="middle" class="terminal-text">'WEDNESDAY'</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M153,134 Q161,134 161,126" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1699693433">
+<g id="172805056">
 <rect x="59" y="158" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="176" text-anchor="middle" class="terminal-text">'THURSDAY'</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M153,172 Q161,172 161,164" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1747632555">
+<g id="1260025325">
 <rect x="66" y="196" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="214" text-anchor="middle" class="terminal-text">'FRIDAY'</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M153,210 Q161,210 161,202" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1824501320">
+<g id="2141040793">
 <rect x="59" y="234" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="252" text-anchor="middle" class="terminal-text">'SATURDAY'</text>
 </g>
@@ -73,7 +73,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M153,248 Q161,248 161,240" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1326960634">
+<g id="1859318668">
 <rect x="66" y="272" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="290" text-anchor="middle" class="terminal-text">'SUNDAY'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_Description.svg
+++ b/docs/railroad/TinyExpressionP4_Description.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Description</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="722906324">
-<g id="888594187">
+<g id="1093060497">
+<g id="1247047945">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'description'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="971739655">
+<g id="1142452907">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'='</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="1095167010">
+<g id="888414368">
 <rect x="232" y="44" width="62" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">STRING</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_EndsWithDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_EndsWithDotMethod.svg
@@ -14,32 +14,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">EndsWithDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="743040281">
-<g id="1310976962">
+<g id="999913186">
+<g id="1304916089">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="1659277935">
+<g id="515496133">
 <rect x="157" y="44" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="205" y="62" text-anchor="middle" class="terminal-text">'.endsWith'</text>
 </g>
 <line x1="254" y1="58" x2="274" y2="58" class="rail"/>
 <polygon points="261,55 267,58 261,61" class="arrow"/>
-<g id="1572531461">
+<g id="1505615123">
 <rect x="274" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="294" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="726070912">
+<g id="495197120">
 <rect x="335" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="467" y1="58" x2="487" y2="58" class="rail"/>
 <polygon points="474,55 480,58 474,61" class="arrow"/>
-<g id="2053793233">
+<g id="1798759601">
 <rect x="487" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="507" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_EndsWithFunction.svg
+++ b/docs/railroad/TinyExpressionP4_EndsWithFunction.svg
@@ -14,38 +14,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">EndsWithFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="824668987">
-<g id="844346833">
+<g id="1331067291">
+<g id="307845661">
 <rect x="40" y="44" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="terminal-text">'endsWith'</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="569311488">
+<g id="1883753878">
 <rect x="150" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="702690356">
+<g id="1553073499">
 <rect x="211" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="277" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="343" y1="58" x2="363" y2="58" class="rail"/>
 <polygon points="350,55 356,58 350,61" class="arrow"/>
-<g id="2142279351">
+<g id="353790503">
 <rect x="363" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="383" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="404" y1="58" x2="424" y2="58" class="rail"/>
 <polygon points="411,55 417,58 411,61" class="arrow"/>
-<g id="1357007277">
+<g id="1304908586">
 <rect x="424" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="490" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="556" y1="58" x2="576" y2="58" class="rail"/>
 <polygon points="563,55 569,58 563,61" class="arrow"/>
-<g id="157066672">
+<g id="52563065">
 <rect x="576" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="596" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_EqualityOp.svg
+++ b/docs/railroad/TinyExpressionP4_EqualityOp.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">EqualityOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="293978780">
-<g id="1890383531">
+<g id="1532755170">
+<g id="64995235">
 <rect x="56" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="62" text-anchor="middle" class="terminal-text">'=='</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="104" y1="58" x2="104" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="104" y1="58" x2="120" y2="58" class="rail"/>
-<g id="250246065">
+<g id="540958948">
 <rect x="56" y="82" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="100" text-anchor="middle" class="terminal-text">'!='</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ExpFunction.svg
+++ b/docs/railroad/TinyExpressionP4_ExpFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExpFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="333841319">
-<g id="176519585">
+<g id="1451384546">
+<g id="1229367069">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'exp'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1950166859">
+<g id="1355094607">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1488615635">
+<g id="504351165">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="839855158">
+<g id="713063136">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_Expression.svg
+++ b/docs/railroad/TinyExpressionP4_Expression.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Expression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="443551978">
-<g id="1661502656">
+<g id="271948418">
+<g id="1688003308">
 <rect x="96" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="228" y1="58" x2="268" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="268" y1="58" x2="284" y2="58" class="rail"/>
-<g id="1205150880">
+<g id="1872808390">
 <rect x="92" y="82" width="139" height="28" class="nonterminal-box"/>
 <text x="161" y="100" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M268,96 Q276,96 276,88" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="2057773121">
+<g id="1617437808">
 <rect x="96" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="138" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M268,134 Q276,134 276,126" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="1667305871">
+<g id="461461202">
 <rect x="96" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="176" text-anchor="middle" class="nonterminal-text">ObjectExpression</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M268,172 Q276,172 276,164" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="1147713447">
+<g id="403262668">
 <rect x="96" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="214" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -63,20 +63,20 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M268,210 Q276,210 276,202" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="54665271">
-<g id="712403886">
+<g id="327092679">
+<g id="1896761586">
 <rect x="56" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="252" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="97" y1="248" x2="117" y2="248" class="rail"/>
 <polygon points="104,245 110,248 104,251" class="arrow"/>
-<g id="1762718601">
+<g id="1348774151">
 <rect x="117" y="234" width="90" height="28" class="nonterminal-box"/>
 <text x="162" y="252" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="207" y1="248" x2="227" y2="248" class="rail"/>
 <polygon points="214,245 220,248 214,251" class="arrow"/>
-<g id="43416141">
+<g id="1103254047">
 <rect x="227" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="247" y="252" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ExternalBooleanInvocation.svg
+++ b/docs/railroad/TinyExpressionP4_ExternalBooleanInvocation.svg
@@ -14,45 +14,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalBooleanInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="897519922">
-<g id="1535602161">
+<g id="134008146">
+<g id="2049941">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="689471660">
+<g id="1019285085">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="1926329995">
+<g id="2550266">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="1722119171">
+<g id="1803422276">
 <rect x="335" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="404" y="80" text-anchor="middle" class="nonterminal-text">BooleanReturnType</text>
 </g>
 <line x1="474" y1="76" x2="494" y2="76" class="rail"/>
 <polygon points="481,73 487,76 481,79" class="arrow"/>
-<g id="103642563">
+<g id="287824721">
 <rect x="494" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="539" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="584" y1="76" x2="604" y2="76" class="rail"/>
 <polygon points="591,73 597,76 591,79" class="arrow"/>
-<g id="1809680458">
+<g id="631282894">
 <rect x="604" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="624" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="645" y1="76" x2="665" y2="76" class="rail"/>
 <polygon points="652,73 658,76 652,79" class="arrow"/>
-<g id="1594471859">
-<g id="306306708">
+<g id="155835544">
+<g id="310302905">
 <rect x="681" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="722" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -66,7 +66,7 @@
 </g>
 <line x1="780" y1="76" x2="800" y2="76" class="rail"/>
 <polygon points="787,73 793,76 787,79" class="arrow"/>
-<g id="854020348">
+<g id="639333299">
 <rect x="800" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="820" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ExternalNumberInvocation.svg
+++ b/docs/railroad/TinyExpressionP4_ExternalNumberInvocation.svg
@@ -14,45 +14,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalNumberInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="250313171">
-<g id="701946999">
+<g id="2082652524">
+<g id="1671652868">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="996167891">
+<g id="608816116">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="856197107">
+<g id="1504883237">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="2117334561">
+<g id="952459804">
 <rect x="335" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="80" text-anchor="middle" class="nonterminal-text">NumberReturnType</text>
 </g>
 <line x1="467" y1="76" x2="487" y2="76" class="rail"/>
 <polygon points="474,73 480,76 474,79" class="arrow"/>
-<g id="1637464308">
+<g id="1085190214">
 <rect x="487" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="532" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="577" y1="76" x2="597" y2="76" class="rail"/>
 <polygon points="584,73 590,76 584,79" class="arrow"/>
-<g id="1481022172">
+<g id="710071756">
 <rect x="597" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="638" y1="76" x2="658" y2="76" class="rail"/>
 <polygon points="645,73 651,76 645,79" class="arrow"/>
-<g id="1323679751">
-<g id="788969784">
+<g id="1979396704">
+<g id="1715300665">
 <rect x="674" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="715" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -66,7 +66,7 @@
 </g>
 <line x1="773" y1="76" x2="793" y2="76" class="rail"/>
 <polygon points="780,73 786,76 780,79" class="arrow"/>
-<g id="1645711159">
+<g id="1080201241">
 <rect x="793" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="813" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ExternalObjectInvocation.svg
+++ b/docs/railroad/TinyExpressionP4_ExternalObjectInvocation.svg
@@ -14,45 +14,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalObjectInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1951719176">
-<g id="1671393424">
+<g id="1348323906">
+<g id="1264449620">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="696413687">
+<g id="517267922">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="1774746077">
+<g id="183179611">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="1983904707">
+<g id="693595763">
 <rect x="335" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="80" text-anchor="middle" class="nonterminal-text">ObjectReturnType</text>
 </g>
 <line x1="467" y1="76" x2="487" y2="76" class="rail"/>
 <polygon points="474,73 480,76 474,79" class="arrow"/>
-<g id="1857822308">
+<g id="233618517">
 <rect x="487" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="532" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="577" y1="76" x2="597" y2="76" class="rail"/>
 <polygon points="584,73 590,76 584,79" class="arrow"/>
-<g id="1416313745">
+<g id="881788491">
 <rect x="597" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="638" y1="76" x2="658" y2="76" class="rail"/>
 <polygon points="645,73 651,76 645,79" class="arrow"/>
-<g id="1999612856">
-<g id="2118628944">
+<g id="1951018506">
+<g id="1719459904">
 <rect x="674" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="715" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -66,7 +66,7 @@
 </g>
 <line x1="773" y1="76" x2="793" y2="76" class="rail"/>
 <polygon points="780,73 786,76 780,79" class="arrow"/>
-<g id="2037306375">
+<g id="481045186">
 <rect x="793" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="813" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ExternalStringInvocation.svg
+++ b/docs/railroad/TinyExpressionP4_ExternalStringInvocation.svg
@@ -14,45 +14,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalStringInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="215115584">
-<g id="339664463">
+<g id="1062443404">
+<g id="1910184816">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="1958465847">
+<g id="1562337049">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="713791136">
+<g id="153743099">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="2138785731">
+<g id="1667921683">
 <rect x="335" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="80" text-anchor="middle" class="nonterminal-text">StringReturnType</text>
 </g>
 <line x1="467" y1="76" x2="487" y2="76" class="rail"/>
 <polygon points="474,73 480,76 474,79" class="arrow"/>
-<g id="500507333">
+<g id="1245966485">
 <rect x="487" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="532" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="577" y1="76" x2="597" y2="76" class="rail"/>
 <polygon points="584,73 590,76 584,79" class="arrow"/>
-<g id="936213025">
+<g id="1828952403">
 <rect x="597" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="638" y1="76" x2="658" y2="76" class="rail"/>
 <polygon points="645,73 651,76 645,79" class="arrow"/>
-<g id="1692784210">
-<g id="1090901230">
+<g id="469357745">
+<g id="731642942">
 <rect x="674" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="715" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -66,7 +66,7 @@
 </g>
 <line x1="773" y1="76" x2="793" y2="76" class="rail"/>
 <polygon points="780,73 786,76 780,79" class="arrow"/>
-<g id="1351750401">
+<g id="1324042243">
 <rect x="793" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="813" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_FloorFunction.svg
+++ b/docs/railroad/TinyExpressionP4_FloorFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">FloorFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="555263205">
-<g id="1179725241">
+<g id="1560342550">
+<g id="1980589462">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'floor'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1650450475">
+<g id="473301631">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1259376661">
+<g id="350511334">
 <rect x="190" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="1852534900">
+<g id="1077681234">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_Formula.svg
+++ b/docs/railroad/TinyExpressionP4_Formula.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Formula</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1952136147">
-<g id="1477801890">
-<g id="1030517929">
+<g id="1255007795">
+<g id="84781591">
+<g id="746523747">
 <rect x="56" y="68" width="83" height="28" class="nonterminal-box"/>
 <text x="97" y="86" text-anchor="middle" class="nonterminal-text">CodeBlock</text>
 </g>
@@ -36,8 +36,8 @@
 </g>
 <line x1="155" y1="58" x2="175" y2="58" class="rail"/>
 <polygon points="162,55 168,58 162,61" class="arrow"/>
-<g id="1697556844">
-<g id="581953305">
+<g id="1274123413">
+<g id="1596775121">
 <rect x="191" y="68" width="139" height="28" class="nonterminal-box"/>
 <text x="260" y="86" text-anchor="middle" class="nonterminal-text">ImportDeclaration</text>
 </g>
@@ -57,8 +57,8 @@
 </g>
 <line x1="346" y1="58" x2="366" y2="58" class="rail"/>
 <polygon points="353,55 359,58 353,61" class="arrow"/>
-<g id="74631988">
-<g id="1999182356">
+<g id="1598012335">
+<g id="931848795">
 <rect x="382" y="68" width="153" height="28" class="nonterminal-box"/>
 <text x="458" y="86" text-anchor="middle" class="nonterminal-text">VariableDeclaration</text>
 </g>
@@ -78,8 +78,8 @@
 </g>
 <line x1="551" y1="58" x2="571" y2="58" class="rail"/>
 <polygon points="558,55 564,58 558,61" class="arrow"/>
-<g id="1238225950">
-<g id="1505260428">
+<g id="569273773">
+<g id="1719408843">
 <rect x="587" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="632" y="86" text-anchor="middle" class="nonterminal-text">Annotation</text>
 </g>
@@ -99,14 +99,14 @@
 </g>
 <line x1="693" y1="58" x2="713" y2="58" class="rail"/>
 <polygon points="700,55 706,58 700,61" class="arrow"/>
-<g id="1988861577">
+<g id="1100401649">
 <rect x="713" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="758" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="803" y1="58" x2="823" y2="58" class="rail"/>
 <polygon points="810,55 816,58 810,61" class="arrow"/>
-<g id="2123168542">
-<g id="1681047559">
+<g id="1701446750">
+<g id="1675031215">
 <rect x="839" y="68" width="139" height="28" class="nonterminal-box"/>
 <text x="908" y="86" text-anchor="middle" class="nonterminal-text">MethodDeclaration</text>
 </g>
@@ -126,7 +126,7 @@
 </g>
 <line x1="994" y1="58" x2="1014" y2="58" class="rail"/>
 <polygon points="1001,55 1007,58 1001,61" class="arrow"/>
-<g id="1506192885">
+<g id="935038555">
 <rect x="1014" y="44" width="41" height="28" class="nonterminal-box"/>
 <text x="1034" y="62" text-anchor="middle" class="nonterminal-text">EOF</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_IfExpression.svg
+++ b/docs/railroad/TinyExpressionP4_IfExpression.svg
@@ -14,68 +14,68 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">IfExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="412310187">
-<g id="1019587679">
+<g id="1919627750">
+<g id="754771922">
 <rect x="40" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="64" y="62" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="88" y1="58" x2="108" y2="58" class="rail"/>
 <polygon points="95,55 101,58 95,61" class="arrow"/>
-<g id="705268622">
+<g id="1147339392">
 <rect x="108" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="128" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="149" y1="58" x2="169" y2="58" class="rail"/>
 <polygon points="156,55 162,58 156,61" class="arrow"/>
-<g id="1196496309">
+<g id="1403248915">
 <rect x="169" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="238" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="308" y1="58" x2="328" y2="58" class="rail"/>
 <polygon points="315,55 321,58 315,61" class="arrow"/>
-<g id="551107050">
+<g id="1984946061">
 <rect x="328" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="348" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="369" y1="58" x2="389" y2="58" class="rail"/>
 <polygon points="376,55 382,58 376,61" class="arrow"/>
-<g id="837803770">
+<g id="1036412129">
 <rect x="389" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="409" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="430" y1="58" x2="450" y2="58" class="rail"/>
 <polygon points="437,55 443,58 437,61" class="arrow"/>
-<g id="1474066098">
+<g id="1634539227">
 <rect x="450" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="495" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="540" y1="58" x2="560" y2="58" class="rail"/>
 <polygon points="547,55 553,58 547,61" class="arrow"/>
-<g id="418331969">
+<g id="764074140">
 <rect x="560" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="580" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
 <line x1="601" y1="58" x2="621" y2="58" class="rail"/>
 <polygon points="608,55 614,58 608,61" class="arrow"/>
-<g id="1905283551">
+<g id="624019735">
 <rect x="621" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="652" y="62" text-anchor="middle" class="terminal-text">'else'</text>
 </g>
 <line x1="683" y1="58" x2="703" y2="58" class="rail"/>
 <polygon points="690,55 696,58 690,61" class="arrow"/>
-<g id="1053251865">
+<g id="735989820">
 <rect x="703" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="723" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="744" y1="58" x2="764" y2="58" class="rail"/>
 <polygon points="751,55 757,58 751,61" class="arrow"/>
-<g id="169525653">
+<g id="579620946">
 <rect x="764" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="809" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="854" y1="58" x2="874" y2="58" class="rail"/>
 <polygon points="861,55 867,58 861,61" class="arrow"/>
-<g id="1811869858">
+<g id="1496916647">
 <rect x="874" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="894" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ImportDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_ImportDeclaration.svg
@@ -14,28 +14,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ImportDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="39343965">
-<g id="392162873">
+<g id="1604952262">
+<g id="2013352497">
 <rect x="40" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="80" text-anchor="middle" class="terminal-text">'import'</text>
 </g>
 <line x1="116" y1="76" x2="136" y2="76" class="rail"/>
 <polygon points="123,73 129,76 123,79" class="arrow"/>
-<g id="883839214">
+<g id="1556666512">
 <rect x="136" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="177" y="80" text-anchor="middle" class="nonterminal-text">ClassName</text>
 </g>
 <line x1="219" y1="76" x2="239" y2="76" class="rail"/>
 <polygon points="226,73 232,76 226,79" class="arrow"/>
-<g id="839381269">
-<g id="244988123">
-<g id="1850311742">
+<g id="1597809012">
+<g id="1029107464">
+<g id="35867580">
 <rect x="255" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="275" y="80" text-anchor="middle" class="terminal-text">'#'</text>
 </g>
 <line x1="296" y1="76" x2="316" y2="76" class="rail"/>
 <polygon points="303,73 309,76 303,79" class="arrow"/>
-<g id="1717316623">
+<g id="1337244693">
 <rect x="316" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="361" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
@@ -50,19 +50,19 @@
 </g>
 <line x1="422" y1="76" x2="442" y2="76" class="rail"/>
 <polygon points="429,73 435,76 429,79" class="arrow"/>
-<g id="1402311827">
+<g id="2109564165">
 <rect x="442" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="466" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="490" y1="76" x2="510" y2="76" class="rail"/>
 <polygon points="497,73 503,76 497,79" class="arrow"/>
-<g id="1083553990">
+<g id="1903945186">
 <rect x="510" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="555" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="600" y1="76" x2="620" y2="76" class="rail"/>
 <polygon points="607,73 613,76 607,79" class="arrow"/>
-<g id="257593594">
+<g id="1705282055">
 <rect x="620" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="640" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_InDayTimeRangeFunction.svg
+++ b/docs/railroad/TinyExpressionP4_InDayTimeRangeFunction.svg
@@ -14,62 +14,62 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">InDayTimeRangeFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1449651851">
-<g id="373584250">
+<g id="6182312">
+<g id="399931158">
 <rect x="40" y="44" width="132" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="terminal-text">'inDayTimeRange'</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="693837815">
+<g id="23129816">
 <rect x="192" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="212" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="233" y1="58" x2="253" y2="58" class="rail"/>
 <polygon points="240,55 246,58 240,61" class="arrow"/>
-<g id="2129541565">
+<g id="520304">
 <rect x="253" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="294" y="62" text-anchor="middle" class="nonterminal-text">DayOfWeek</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="329062762">
+<g id="202607388">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="397" y1="58" x2="417" y2="58" class="rail"/>
 <polygon points="404,55 410,58 404,61" class="arrow"/>
-<g id="644314562">
+<g id="676934479">
 <rect x="417" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="483" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="549" y1="58" x2="569" y2="58" class="rail"/>
 <polygon points="556,55 562,58 556,61" class="arrow"/>
-<g id="1462923870">
+<g id="776543922">
 <rect x="569" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="589" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="610" y1="58" x2="630" y2="58" class="rail"/>
 <polygon points="617,55 623,58 617,61" class="arrow"/>
-<g id="1478400724">
+<g id="301137787">
 <rect x="630" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="671" y="62" text-anchor="middle" class="nonterminal-text">DayOfWeek</text>
 </g>
 <line x1="713" y1="58" x2="733" y2="58" class="rail"/>
 <polygon points="720,55 726,58 720,61" class="arrow"/>
-<g id="598974196">
+<g id="27905330">
 <rect x="733" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="753" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="774" y1="58" x2="794" y2="58" class="rail"/>
 <polygon points="781,55 787,58 781,61" class="arrow"/>
-<g id="1046951461">
+<g id="1611355395">
 <rect x="794" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="860" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="926" y1="58" x2="946" y2="58" class="rail"/>
 <polygon points="933,55 939,58 933,61" class="arrow"/>
-<g id="2055410485">
+<g id="106003262">
 <rect x="946" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="966" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_InMethod.svg
+++ b/docs/railroad/TinyExpressionP4_InMethod.svg
@@ -14,40 +14,40 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">InMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1436324046">
-<g id="1781969154">
+<g id="1383051965">
+<g id="21040958">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="112584851">
+<g id="408148425">
 <rect x="192" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="219" y="62" text-anchor="middle" class="terminal-text">'.in'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="1105198150">
+<g id="616674825">
 <rect x="267" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="287" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="308" y1="58" x2="328" y2="58" class="rail"/>
 <polygon points="315,55 321,58 315,61" class="arrow"/>
-<g id="278795895">
+<g id="248861487">
 <rect x="328" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="394" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="460" y1="58" x2="480" y2="58" class="rail"/>
 <polygon points="467,55 473,58 467,61" class="arrow"/>
-<g id="946468440">
-<g id="1487175317">
-<g id="1342114759">
+<g id="206529624">
+<g id="682038856">
+<g id="132420916">
 <rect x="496" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="516" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="537" y1="82" x2="557" y2="82" class="rail"/>
 <polygon points="544,79 550,82 544,85" class="arrow"/>
-<g id="1713869787">
+<g id="25139600">
 <rect x="557" y="68" width="132" height="28" class="nonterminal-box"/>
 <text x="623" y="86" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -68,7 +68,7 @@
 </g>
 <line x1="705" y1="58" x2="725" y2="58" class="rail"/>
 <polygon points="712,55 718,58 712,61" class="arrow"/>
-<g id="268399521">
+<g id="790699472">
 <rect x="725" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="745" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_InTimeRangeFunction.svg
+++ b/docs/railroad/TinyExpressionP4_InTimeRangeFunction.svg
@@ -14,38 +14,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">InTimeRangeFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1381493051">
-<g id="89290535">
+<g id="675584911">
+<g id="721910807">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'inTimeRange'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="60992370">
+<g id="154011989">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="1379217096">
+<g id="102001285">
 <rect x="232" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="298" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="364" y1="58" x2="384" y2="58" class="rail"/>
 <polygon points="371,55 377,58 371,61" class="arrow"/>
-<g id="704488798">
+<g id="1682668741">
 <rect x="384" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="404" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="425" y1="58" x2="445" y2="58" class="rail"/>
 <polygon points="432,55 438,58 432,61" class="arrow"/>
-<g id="1056965641">
+<g id="1958499231">
 <rect x="445" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="511" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="577" y1="58" x2="597" y2="58" class="rail"/>
 <polygon points="584,55 590,58 584,61" class="arrow"/>
-<g id="703578528">
+<g id="228694268">
 <rect x="597" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_IsPresentFunction.svg
+++ b/docs/railroad/TinyExpressionP4_IsPresentFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">IsPresentFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1520706274">
-<g id="491320705">
+<g id="1629512617">
+<g id="1837642115">
 <rect x="40" y="44" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="terminal-text">'isPresent'</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="1830176742">
+<g id="412770020">
 <rect x="157" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="177" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="198" y1="58" x2="218" y2="58" class="rail"/>
 <polygon points="205,55 211,58 205,61" class="arrow"/>
-<g id="585404997">
+<g id="798077785">
 <rect x="218" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="266" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="10103693">
+<g id="1292388258">
 <rect x="335" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_LenFunction.svg
+++ b/docs/railroad/TinyExpressionP4_LenFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LenFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="659846761">
-<g id="1206748278">
+<g id="710492053">
+<g id="555180083">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'len'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1382879663">
+<g id="176475926">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1782232927">
+<g id="1153118359">
 <rect x="176" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="242" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="308" y1="58" x2="328" y2="58" class="rail"/>
 <polygon points="315,55 321,58 315,61" class="arrow"/>
-<g id="204578221">
+<g id="819316548">
 <rect x="328" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="348" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_LengthDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_LengthDotMethod.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LengthDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1632325264">
-<g id="1577902559">
+<g id="1570491305">
+<g id="1311985693">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="2112395885">
+<g id="1649792321">
 <rect x="157" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="62" text-anchor="middle" class="terminal-text">'.length'</text>
 </g>
 <line x1="240" y1="58" x2="260" y2="58" class="rail"/>
 <polygon points="247,55 253,58 247,61" class="arrow"/>
-<g id="620777145">
+<g id="84713614">
 <rect x="260" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="280" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="301" y1="58" x2="321" y2="58" class="rail"/>
 <polygon points="308,55 314,58 308,61" class="arrow"/>
-<g id="1483759192">
+<g id="159174947">
 <rect x="321" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="341" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_LengthFunction.svg
+++ b/docs/railroad/TinyExpressionP4_LengthFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LengthFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="930751215">
-<g id="544562857">
+<g id="1878224161">
+<g id="1412551404">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'length'</text>
 </g>
 <line x1="116" y1="58" x2="136" y2="58" class="rail"/>
 <polygon points="123,55 129,58 123,61" class="arrow"/>
-<g id="35544865">
+<g id="175675974">
 <rect x="136" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="177" y1="58" x2="197" y2="58" class="rail"/>
 <polygon points="184,55 190,58 184,61" class="arrow"/>
-<g id="382761148">
+<g id="178533268">
 <rect x="197" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="1030796286">
+<g id="898592718">
 <rect x="349" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="369" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_LogFunction.svg
+++ b/docs/railroad/TinyExpressionP4_LogFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LogFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="249331810">
-<g id="699234801">
+<g id="229057415">
+<g id="585193573">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'log'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="45145517">
+<g id="1847939086">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="68114747">
+<g id="1575521876">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1291586301">
+<g id="623732023">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MathFunction.svg
+++ b/docs/railroad/TinyExpressionP4_MathFunction.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MathFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1078775689">
-<g id="854923266">
+<g id="1434148430">
+<g id="738596700">
 <rect x="66" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="62" text-anchor="middle" class="nonterminal-text">SinFunction</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="163" y1="58" x2="174" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="174" y1="58" x2="190" y2="58" class="rail"/>
-<g id="939508817">
+<g id="302751348">
 <rect x="66" y="82" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="100" text-anchor="middle" class="nonterminal-text">CosFunction</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M174,96 Q182,96 182,88" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="534340601">
+<g id="1743707267">
 <rect x="66" y="120" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="138" text-anchor="middle" class="nonterminal-text">TanFunction</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M174,134 Q182,134 182,126" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1884785804">
+<g id="1464426145">
 <rect x="63" y="158" width="104" height="28" class="nonterminal-box"/>
 <text x="115" y="176" text-anchor="middle" class="nonterminal-text">SqrtFunction</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M174,172 Q182,172 182,164" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1786298252">
+<g id="1273565155">
 <rect x="66" y="196" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="214" text-anchor="middle" class="nonterminal-text">MinFunction</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M174,210 Q182,210 182,202" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="602678238">
+<g id="98554068">
 <rect x="66" y="234" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="252" text-anchor="middle" class="nonterminal-text">MaxFunction</text>
 </g>
@@ -73,7 +73,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M174,248 Q182,248 182,240" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="2013154033">
+<g id="348397096">
 <rect x="56" y="272" width="118" height="28" class="nonterminal-box"/>
 <text x="115" y="290" text-anchor="middle" class="nonterminal-text">RandomFunction</text>
 </g>
@@ -83,7 +83,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M174,286 Q182,286 182,278" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="989956974">
+<g id="166065735">
 <rect x="66" y="310" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="328" text-anchor="middle" class="nonterminal-text">AbsFunction</text>
 </g>
@@ -93,7 +93,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M174,324 Q182,324 182,316" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="338351965">
+<g id="183527055">
 <rect x="59" y="348" width="111" height="28" class="nonterminal-box"/>
 <text x="114" y="366" text-anchor="middle" class="nonterminal-text">RoundFunction</text>
 </g>
@@ -103,7 +103,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M174,362 Q182,362 182,354" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1452991701">
+<g id="1901219445">
 <rect x="63" y="386" width="104" height="28" class="nonterminal-box"/>
 <text x="115" y="404" text-anchor="middle" class="nonterminal-text">CeilFunction</text>
 </g>
@@ -113,7 +113,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M174,400 Q182,400 182,392" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1396086069">
+<g id="1163082537">
 <rect x="59" y="424" width="111" height="28" class="nonterminal-box"/>
 <text x="114" y="442" text-anchor="middle" class="nonterminal-text">FloorFunction</text>
 </g>
@@ -123,7 +123,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M174,438 Q182,438 182,430" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1683697350">
+<g id="1671608842">
 <rect x="66" y="462" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="480" text-anchor="middle" class="nonterminal-text">PowFunction</text>
 </g>
@@ -133,7 +133,7 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M174,476 Q182,476 182,468" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="638164271">
+<g id="1794075887">
 <rect x="66" y="500" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="518" text-anchor="middle" class="nonterminal-text">LogFunction</text>
 </g>
@@ -143,7 +143,7 @@
 <path d="M48,506 Q48,514 56,514" class="rail" fill="none"/>
 <path d="M174,514 Q182,514 182,506" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="666134903">
+<g id="162379297">
 <rect x="66" y="538" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="556" text-anchor="middle" class="nonterminal-text">ExpFunction</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MaxFunction.svg
+++ b/docs/railroad/TinyExpressionP4_MaxFunction.svg
@@ -14,34 +14,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MaxFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="233991583">
-<g id="1384739151">
+<g id="1761201139">
+<g id="564940456">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'max'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="751029021">
+<g id="1091588081">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="2077145329">
+<g id="1584525123">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1150474396">
-<g id="1242949663">
-<g id="1629903172">
+<g id="2112300187">
+<g id="750640568">
+<g id="747350619">
 <rect x="358" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="378" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="399" y1="82" x2="419" y2="82" class="rail"/>
 <polygon points="406,79 412,82 406,85" class="arrow"/>
-<g id="2017218342">
+<g id="1863411820">
 <rect x="419" y="68" width="146" height="28" class="nonterminal-box"/>
 <text x="492" y="86" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
@@ -62,7 +62,7 @@
 </g>
 <line x1="581" y1="58" x2="601" y2="58" class="rail"/>
 <polygon points="588,55 594,58 588,61" class="arrow"/>
-<g id="397235507">
+<g id="214925326">
 <rect x="601" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="621" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MethodDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_MethodDeclaration.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodDeclaration</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="692288323">
-<g id="1183011255">
+<g id="139093477">
+<g id="71286098">
 <rect x="59" y="44" width="181" height="28" class="nonterminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="nonterminal-text">NumberMethodDeclaration</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="240" y1="58" x2="244" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="244" y1="58" x2="260" y2="58" class="rail"/>
-<g id="936450514">
+<g id="1081846417">
 <rect x="59" y="82" width="181" height="28" class="nonterminal-box"/>
 <text x="149" y="100" text-anchor="middle" class="nonterminal-text">StringMethodDeclaration</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M244,96 Q252,96 252,88" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="114552127">
+<g id="1324623255">
 <rect x="56" y="120" width="188" height="28" class="nonterminal-box"/>
 <text x="150" y="138" text-anchor="middle" class="nonterminal-text">BooleanMethodDeclaration</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M244,134 Q252,134 252,126" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1964081855">
+<g id="1910932390">
 <rect x="59" y="158" width="181" height="28" class="nonterminal-box"/>
 <text x="149" y="176" text-anchor="middle" class="nonterminal-text">ObjectMethodDeclaration</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MethodInvocation.svg
+++ b/docs/railroad/TinyExpressionP4_MethodInvocation.svg
@@ -14,27 +14,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="882561843">
-<g id="1100662035">
+<g id="2048858427">
+<g id="925507114">
 <rect x="40" y="62" width="174" height="28" class="nonterminal-box"/>
 <text x="127" y="80" text-anchor="middle" class="nonterminal-text">MethodInvocationHeader</text>
 </g>
 <line x1="214" y1="76" x2="234" y2="76" class="rail"/>
 <polygon points="221,73 227,76 221,79" class="arrow"/>
-<g id="161314698">
+<g id="1486717668">
 <rect x="234" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="279" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="324" y1="76" x2="344" y2="76" class="rail"/>
 <polygon points="331,73 337,76 331,79" class="arrow"/>
-<g id="1956842394">
+<g id="1113659495">
 <rect x="344" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="364" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="385" y1="76" x2="405" y2="76" class="rail"/>
 <polygon points="392,73 398,76 392,79" class="arrow"/>
-<g id="977988999">
-<g id="762251108">
+<g id="71935421">
+<g id="1677016231">
 <rect x="421" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="462" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -48,7 +48,7 @@
 </g>
 <line x1="520" y1="76" x2="540" y2="76" class="rail"/>
 <polygon points="527,73 533,76 527,79" class="arrow"/>
-<g id="1485438051">
+<g id="813141362">
 <rect x="540" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="560" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MethodInvocationHeader.svg
+++ b/docs/railroad/TinyExpressionP4_MethodInvocationHeader.svg
@@ -14,16 +14,16 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodInvocationHeader</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="711880557">
-<g id="1613040991">
-<g id="929170148">
+<g id="1748574597">
+<g id="931859049">
+<g id="1361207017">
 <rect x="56" y="62" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="87" y="80" text-anchor="middle" class="terminal-text">'call'</text>
 </g>
 <line x1="118" y1="76" x2="138" y2="76" class="rail"/>
 <polygon points="125,73 131,76 125,79" class="arrow"/>
-<g id="853227667">
-<g id="1025121755">
+<g id="154848982">
+<g id="1958547641">
 <rect x="154" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="199" y="80" text-anchor="middle" class="terminal-text">'internal'</text>
 </g>
@@ -40,7 +40,7 @@
 <line x1="260" y1="76" x2="260" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="260" y1="76" x2="276" y2="76" class="rail"/>
-<g id="1199003293">
+<g id="1948110695">
 <rect x="113" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="158" y="118" text-anchor="middle" class="terminal-text">'internal'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MethodParameter.svg
+++ b/docs/railroad/TinyExpressionP4_MethodParameter.svg
@@ -14,28 +14,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodParameter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1560507072">
-<g id="1729495359">
+<g id="1606110544">
+<g id="1226280974">
 <rect x="40" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="81" y1="76" x2="101" y2="76" class="rail"/>
 <polygon points="88,73 94,76 88,79" class="arrow"/>
-<g id="1842461637">
+<g id="1162786169">
 <rect x="101" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="146" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="191" y1="76" x2="211" y2="76" class="rail"/>
 <polygon points="198,73 204,76 198,79" class="arrow"/>
-<g id="665997686">
-<g id="1205720539">
-<g id="170794172">
+<g id="767706638">
+<g id="488099240">
+<g id="1927286131">
 <rect x="227" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="251" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="275" y1="76" x2="295" y2="76" class="rail"/>
 <polygon points="282,73 288,76 282,79" class="arrow"/>
-<g id="278208783">
+<g id="1760929624">
 <rect x="295" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="340" y="80" text-anchor="middle" class="nonterminal-text">ReturnType</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MethodParameters.svg
+++ b/docs/railroad/TinyExpressionP4_MethodParameters.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodParameters</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1745765867">
-<g id="1857893612">
+<g id="349297612">
+<g id="576376033">
 <rect x="40" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="102" y="62" text-anchor="middle" class="nonterminal-text">MethodParameter</text>
 </g>
 <line x1="165" y1="58" x2="185" y2="58" class="rail"/>
 <polygon points="172,55 178,58 172,61" class="arrow"/>
-<g id="978037345">
-<g id="1029108595">
-<g id="644779820">
+<g id="953284874">
+<g id="1285032380">
+<g id="497426773">
 <rect x="201" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="221" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="242" y1="82" x2="262" y2="82" class="rail"/>
 <polygon points="249,79 255,82 249,85" class="arrow"/>
-<g id="329488027">
+<g id="621744794">
 <rect x="262" y="68" width="125" height="28" class="nonterminal-box"/>
 <text x="324" y="86" text-anchor="middle" class="nonterminal-text">MethodParameter</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MinFunction.svg
+++ b/docs/railroad/TinyExpressionP4_MinFunction.svg
@@ -14,34 +14,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MinFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="982781120">
-<g id="2021856370">
+<g id="876140032">
+<g id="1253748141">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'min'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="304389006">
+<g id="1854783010">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="400267621">
+<g id="2144120701">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1599355911">
-<g id="344952642">
-<g id="1107371209">
+<g id="1800499637">
+<g id="1903988640">
+<g id="1842039997">
 <rect x="358" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="378" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="399" y1="82" x2="419" y2="82" class="rail"/>
 <polygon points="406,79 412,82 406,85" class="arrow"/>
-<g id="583112831">
+<g id="1912820588">
 <rect x="419" y="68" width="146" height="28" class="nonterminal-box"/>
 <text x="492" y="86" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
@@ -62,7 +62,7 @@
 </g>
 <line x1="581" y1="58" x2="601" y2="58" class="rail"/>
 <polygon points="588,55 594,58 588,61" class="arrow"/>
-<g id="347634760">
+<g id="1556637382">
 <rect x="601" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="621" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_MulOp.svg
+++ b/docs/railroad/TinyExpressionP4_MulOp.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MulOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="122492291">
-<g id="153191880">
+<g id="1566419270">
+<g id="1116702615">
 <rect x="56" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="62" text-anchor="middle" class="terminal-text">'*'</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="97" y1="58" x2="97" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="97" y1="58" x2="113" y2="58" class="rail"/>
-<g id="58031976">
+<g id="1251471606">
 <rect x="56" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="100" text-anchor="middle" class="terminal-text">'/'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NotExpression.svg
+++ b/docs/railroad/TinyExpressionP4_NotExpression.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NotExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="12775056">
-<g id="392059312">
+<g id="1236191924">
+<g id="2077826974">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1711204971">
+<g id="614635906">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1007446155">
+<g id="1008882118">
 <rect x="176" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="245" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="1697953887">
+<g id="2058887058">
 <rect x="335" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberCase.svg
+++ b/docs/railroad/TinyExpressionP4_NumberCase.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1981749521">
-<g id="1492015044">
+<g id="1298174155">
+<g id="288651511">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="2031191727">
+<g id="1374643732">
 <rect x="199" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="223" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="1221195984">
+<g id="237153124">
 <rect x="267" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="329" y="62" text-anchor="middle" class="nonterminal-text">NumberCaseValue</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberCaseValue.svg
+++ b/docs/railroad/TinyExpressionP4_NumberCaseValue.svg
@@ -14,7 +14,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberCaseValue</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1442187808">
+<g id="1972943487">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberDefaultCase.svg
+++ b/docs/railroad/TinyExpressionP4_NumberDefaultCase.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberDefaultCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="543539301">
-<g id="1558519905">
+<g id="119108582">
+<g id="2141301328">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'default'</text>
 </g>
 <line x1="123" y1="58" x2="143" y2="58" class="rail"/>
 <polygon points="130,55 136,58 130,61" class="arrow"/>
-<g id="699724204">
+<g id="1431616630">
 <rect x="143" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="784106290">
+<g id="1320567859">
 <rect x="211" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="273" y="62" text-anchor="middle" class="nonterminal-text">NumberCaseValue</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberExpression.svg
+++ b/docs/railroad/TinyExpressionP4_NumberExpression.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1986247810">
-<g id="79928291">
+<g id="877482205">
+<g id="188002971">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">NumberTerm</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="888804702">
-<g id="754884513">
-<g id="272260135">
+<g id="1529265208">
+<g id="1965586540">
+<g id="337601394">
 <rect x="166" y="68" width="55" height="28" class="nonterminal-box"/>
 <text x="193" y="86" text-anchor="middle" class="nonterminal-text">AddOp</text>
 </g>
 <line x1="221" y1="82" x2="241" y2="82" class="rail"/>
 <polygon points="228,79 234,82 228,85" class="arrow"/>
-<g id="469551838">
+<g id="1075828973">
 <rect x="241" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="286" y="86" text-anchor="middle" class="nonterminal-text">NumberTerm</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberFactor.svg
+++ b/docs/railroad/TinyExpressionP4_NumberFactor.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberFactor</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="305630133">
-<g id="1064233831">
+<g id="1800539507">
+<g id="488981417">
 <rect x="113" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="182" y="62" text-anchor="middle" class="nonterminal-text">TernaryExpression</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="252" y1="58" x2="310" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="310" y1="58" x2="326" y2="58" class="rail"/>
-<g id="1750335227">
+<g id="1846767880">
 <rect x="99" y="82" width="167" height="28" class="nonterminal-box"/>
 <text x="182" y="100" text-anchor="middle" class="nonterminal-text">NumberMatchExpression</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M310,96 Q318,96 318,88" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="2141332149">
+<g id="665704836">
 <rect x="131" y="120" width="104" height="28" class="nonterminal-box"/>
 <text x="183" y="138" text-anchor="middle" class="nonterminal-text">IfExpression</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M310,134 Q318,134 318,126" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="1183002939">
+<g id="794232141">
 <rect x="131" y="158" width="104" height="28" class="nonterminal-box"/>
 <text x="183" y="176" text-anchor="middle" class="nonterminal-text">MathFunction</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M310,172 Q318,172 318,164" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="243195743">
+<g id="416822021">
 <rect x="127" y="196" width="111" height="28" class="nonterminal-box"/>
 <text x="182" y="214" text-anchor="middle" class="nonterminal-text">ToNumFunction</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M310,210 Q318,210 318,202" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="2041400397">
+<g id="1840679463">
 <rect x="120" y="234" width="125" height="28" class="nonterminal-box"/>
 <text x="182" y="252" text-anchor="middle" class="nonterminal-text">LengthDotMethod</text>
 </g>
@@ -73,7 +73,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M310,248 Q318,248 318,240" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="393506375">
+<g id="605954028">
 <rect x="134" y="272" width="97" height="28" class="nonterminal-box"/>
 <text x="182" y="290" text-anchor="middle" class="nonterminal-text">LenFunction</text>
 </g>
@@ -83,7 +83,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M310,286 Q318,286 318,278" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="1210163067">
+<g id="871635791">
 <rect x="124" y="310" width="118" height="28" class="nonterminal-box"/>
 <text x="183" y="328" text-anchor="middle" class="nonterminal-text">LengthFunction</text>
 </g>
@@ -93,7 +93,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M310,324 Q318,324 318,316" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="819799303">
+<g id="1793934895">
 <rect x="89" y="348" width="188" height="28" class="nonterminal-box"/>
 <text x="183" y="366" text-anchor="middle" class="nonterminal-text">ExternalNumberInvocation</text>
 </g>
@@ -103,7 +103,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M310,362 Q318,362 318,354" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="595712117">
+<g id="869474023">
 <rect x="152" y="386" width="62" height="28" class="nonterminal-box"/>
 <text x="183" y="404" text-anchor="middle" class="nonterminal-text">NUMBER</text>
 </g>
@@ -113,7 +113,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M310,400 Q318,400 318,392" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="397642772">
+<g id="1734776334">
 <rect x="134" y="424" width="97" height="28" class="nonterminal-box"/>
 <text x="182" y="442" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -123,7 +123,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M310,438 Q318,438 318,430" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="1403851742">
+<g id="1960560590">
 <rect x="117" y="462" width="132" height="28" class="nonterminal-box"/>
 <text x="183" y="480" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -133,20 +133,20 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M310,476 Q318,476 318,468" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="398392474">
-<g id="167895473">
+<g id="641884148">
+<g id="1946626884">
 <rect x="56" y="500" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="518" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="97" y1="514" x2="117" y2="514" class="rail"/>
 <polygon points="104,511 110,514 104,517" class="arrow"/>
-<g id="661570292">
+<g id="1594369797">
 <rect x="117" y="500" width="132" height="28" class="nonterminal-box"/>
 <text x="183" y="518" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="249" y1="514" x2="269" y2="514" class="rail"/>
 <polygon points="256,511 262,514 256,517" class="arrow"/>
-<g id="741746977">
+<g id="202185740">
 <rect x="269" y="500" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="289" y="518" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberMatchExpression.svg
+++ b/docs/railroad/TinyExpressionP4_NumberMatchExpression.svg
@@ -14,34 +14,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberMatchExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1818902616">
-<g id="562339663">
+<g id="1054845888">
+<g id="1841084466">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'match'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1311828427">
+<g id="814830953">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1464825946">
+<g id="43119331">
 <rect x="190" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="235" y="62" text-anchor="middle" class="nonterminal-text">NumberCase</text>
 </g>
 <line x1="280" y1="58" x2="300" y2="58" class="rail"/>
 <polygon points="287,55 293,58 287,61" class="arrow"/>
-<g id="283253884">
-<g id="1011039750">
-<g id="1880057979">
+<g id="1311501156">
+<g id="1134567193">
+<g id="1901423737">
 <rect x="316" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="336" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="357" y1="82" x2="377" y2="82" class="rail"/>
 <polygon points="364,79 370,82 364,85" class="arrow"/>
-<g id="1970601938">
+<g id="2032154441">
 <rect x="377" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="422" y="86" text-anchor="middle" class="nonterminal-text">NumberCase</text>
 </g>
@@ -62,19 +62,19 @@
 </g>
 <line x1="483" y1="58" x2="503" y2="58" class="rail"/>
 <polygon points="490,55 496,58 490,61" class="arrow"/>
-<g id="463856299">
+<g id="348614780">
 <rect x="503" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="523" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="544" y1="58" x2="564" y2="58" class="rail"/>
 <polygon points="551,55 557,58 551,61" class="arrow"/>
-<g id="1241318498">
+<g id="1814398930">
 <rect x="564" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="633" y="62" text-anchor="middle" class="nonterminal-text">NumberDefaultCase</text>
 </g>
 <line x1="703" y1="58" x2="723" y2="58" class="rail"/>
 <polygon points="710,55 716,58 710,61" class="arrow"/>
-<g id="1818992725">
+<g id="800986520">
 <rect x="723" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="743" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberMethodDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_NumberMethodDeclaration.svg
@@ -14,27 +14,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="953784350">
-<g id="384038960">
+<g id="1184766982">
+<g id="368605535">
 <rect x="40" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="80" text-anchor="middle" class="nonterminal-text">NumberReturnType</text>
 </g>
 <line x1="172" y1="76" x2="192" y2="76" class="rail"/>
 <polygon points="179,73 185,76 179,79" class="arrow"/>
-<g id="264263110">
+<g id="2052013802">
 <rect x="192" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="282" y1="76" x2="302" y2="76" class="rail"/>
 <polygon points="289,73 295,76 289,79" class="arrow"/>
-<g id="1992112891">
+<g id="1064401334">
 <rect x="302" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="322" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="343" y1="76" x2="363" y2="76" class="rail"/>
 <polygon points="350,73 356,76 350,79" class="arrow"/>
-<g id="1304267990">
-<g id="1150737932">
+<g id="841742775">
+<g id="1691305712">
 <rect x="379" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="445" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -48,25 +48,25 @@
 </g>
 <line x1="527" y1="76" x2="547" y2="76" class="rail"/>
 <polygon points="534,73 540,76 534,79" class="arrow"/>
-<g id="1079938754">
+<g id="831535478">
 <rect x="547" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="567" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="588" y1="76" x2="608" y2="76" class="rail"/>
 <polygon points="595,73 601,76 595,79" class="arrow"/>
-<g id="1596661456">
+<g id="85482043">
 <rect x="608" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="628" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="649" y1="76" x2="669" y2="76" class="rail"/>
 <polygon points="656,73 662,76 656,79" class="arrow"/>
-<g id="767548807">
+<g id="469660846">
 <rect x="669" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="735" y="80" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="801" y1="76" x2="821" y2="76" class="rail"/>
 <polygon points="808,73 814,76 808,79" class="arrow"/>
-<g id="214253530">
+<g id="1995816999">
 <rect x="821" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="841" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberReturnType.svg
+++ b/docs/railroad/TinyExpressionP4_NumberReturnType.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2029063772">
-<g id="1688710454">
+<g id="103143918">
+<g id="439479960">
 <rect x="56" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="94" y="62" text-anchor="middle" class="terminal-text">'number'</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="132" y1="58" x2="132" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="132" y1="58" x2="148" y2="58" class="rail"/>
-<g id="1308479348">
+<g id="963123963">
 <rect x="59" y="82" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="93" y="100" text-anchor="middle" class="terminal-text">'float'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberSetter.svg
+++ b/docs/railroad/TinyExpressionP4_NumberSetter.svg
@@ -14,28 +14,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="933361453">
-<g id="135769997">
+<g id="227445305">
+<g id="1747249399">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="1502329223">
-<g id="1216855283">
-<g id="80914917">
+<g id="678713892">
+<g id="824017017">
+<g id="739683522">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="1150545614">
+<g id="1929683291">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="2102992658">
+<g id="2125577224">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -50,7 +50,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="45468134">
+<g id="2116827144">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberTerm.svg
+++ b/docs/railroad/TinyExpressionP4_NumberTerm.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberTerm</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1480774781">
-<g id="196358826">
+<g id="1432303094">
+<g id="170601993">
 <rect x="40" y="44" width="104" height="28" class="nonterminal-box"/>
 <text x="92" y="62" text-anchor="middle" class="nonterminal-text">NumberFactor</text>
 </g>
 <line x1="144" y1="58" x2="164" y2="58" class="rail"/>
 <polygon points="151,55 157,58 151,61" class="arrow"/>
-<g id="1992060327">
-<g id="1555506681">
-<g id="1408219114">
+<g id="1606563114">
+<g id="214567388">
+<g id="1022811192">
 <rect x="180" y="68" width="55" height="28" class="nonterminal-box"/>
 <text x="207" y="86" text-anchor="middle" class="nonterminal-text">MulOp</text>
 </g>
 <line x1="235" y1="82" x2="255" y2="82" class="rail"/>
 <polygon points="242,79 248,82 242,85" class="arrow"/>
-<g id="937105452">
+<g id="1390371042">
 <rect x="255" y="68" width="104" height="28" class="nonterminal-box"/>
 <text x="307" y="86" text-anchor="middle" class="nonterminal-text">NumberFactor</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberTypeHint.svg
+++ b/docs/railroad/TinyExpressionP4_NumberTypeHint.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="2122599488">
-<g id="1776932263">
-<g id="93877542">
+<g id="1269056972">
+<g id="1004995536">
+<g id="1742846421">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -30,8 +30,8 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1752184716">
-<g id="69644314">
+<g id="1094413015">
+<g id="253811086">
 <rect x="156" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="194" y="80" text-anchor="middle" class="terminal-text">'number'</text>
 </g>
@@ -39,7 +39,7 @@
 <line x1="232" y1="76" x2="232" y2="76" class="rail"/>
 <line x1="140" y1="76" x2="156" y2="76" class="rail"/>
 <line x1="232" y1="76" x2="248" y2="76" class="rail"/>
-<g id="772228655">
+<g id="729694588">
 <rect x="159" y="100" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="193" y="118" text-anchor="middle" class="terminal-text">'float'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_NumberVariableDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_NumberVariableDeclaration.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1255914800">
-<g id="1305787071">
-<g id="849407531">
+<g id="1133692791">
+<g id="1503676706">
+<g id="1152041657">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -24,7 +24,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="600146705">
+<g id="852172222">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -37,20 +37,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1340953555">
+<g id="676405795">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="1782332500">
+<g id="1235749761">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="1216139296">
-<g id="1452100458">
+<g id="129654765">
+<g id="608978003">
 <rect x="369" y="62" width="118" height="28" class="nonterminal-box"/>
 <text x="428" y="80" text-anchor="middle" class="nonterminal-text">NumberTypeHint</text>
 </g>
@@ -64,8 +64,8 @@
 </g>
 <line x1="503" y1="76" x2="523" y2="76" class="rail"/>
 <polygon points="510,73 516,76 510,79" class="arrow"/>
-<g id="1728003658">
-<g id="1839882551">
+<g id="791070282">
+<g id="643511555">
 <rect x="539" y="62" width="104" height="28" class="nonterminal-box"/>
 <text x="591" y="80" text-anchor="middle" class="nonterminal-text">NumberSetter</text>
 </g>
@@ -79,13 +79,13 @@
 </g>
 <line x1="659" y1="76" x2="679" y2="76" class="rail"/>
 <polygon points="666,73 672,76 666,79" class="arrow"/>
-<g id="1519779812">
+<g id="1770938657">
 <rect x="679" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="727" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="776" y1="76" x2="796" y2="76" class="rail"/>
 <polygon points="783,73 789,76 783,79" class="arrow"/>
-<g id="1959184710">
+<g id="1016995530">
 <rect x="796" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="816" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ObjectExpression.svg
+++ b/docs/railroad/TinyExpressionP4_ObjectExpression.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1655749630">
-<g id="1490089388">
+<g id="803292439">
+<g id="317743079">
 <rect x="84" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="150" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="216" y1="58" x2="244" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="244" y1="58" x2="260" y2="58" class="rail"/>
-<g id="2086178075">
+<g id="1767487688">
 <rect x="84" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="150" y="100" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M244,96 Q252,96 252,88" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1113241565">
+<g id="925090609">
 <rect x="80" y="120" width="139" height="28" class="nonterminal-box"/>
 <text x="149" y="138" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M244,134 Q252,134 252,126" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="317294663">
+<g id="844511488">
 <rect x="56" y="158" width="188" height="28" class="nonterminal-box"/>
 <text x="150" y="176" text-anchor="middle" class="nonterminal-text">ExternalObjectInvocation</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M244,172 Q252,172 252,164" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1305178659">
+<g id="575231946">
 <rect x="101" y="196" width="97" height="28" class="nonterminal-box"/>
 <text x="149" y="214" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M244,210 Q252,210 252,202" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1967328980">
+<g id="116536499">
 <rect x="84" y="234" width="132" height="28" class="nonterminal-box"/>
 <text x="150" y="252" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ObjectMethodDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_ObjectMethodDeclaration.svg
@@ -14,27 +14,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1606302880">
-<g id="1134287208">
+<g id="1198903654">
+<g id="122015055">
 <rect x="40" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="80" text-anchor="middle" class="nonterminal-text">ObjectReturnType</text>
 </g>
 <line x1="172" y1="76" x2="192" y2="76" class="rail"/>
 <polygon points="179,73 185,76 179,79" class="arrow"/>
-<g id="1673748010">
+<g id="1150164191">
 <rect x="192" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="282" y1="76" x2="302" y2="76" class="rail"/>
 <polygon points="289,73 295,76 289,79" class="arrow"/>
-<g id="717153527">
+<g id="121637369">
 <rect x="302" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="322" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="343" y1="76" x2="363" y2="76" class="rail"/>
 <polygon points="350,73 356,76 350,79" class="arrow"/>
-<g id="1110775724">
-<g id="1610139042">
+<g id="1306995646">
+<g id="1684127176">
 <rect x="379" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="445" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -48,25 +48,25 @@
 </g>
 <line x1="527" y1="76" x2="547" y2="76" class="rail"/>
 <polygon points="534,73 540,76 534,79" class="arrow"/>
-<g id="998122446">
+<g id="2033958457">
 <rect x="547" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="567" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="588" y1="76" x2="608" y2="76" class="rail"/>
 <polygon points="595,73 601,76 595,79" class="arrow"/>
-<g id="1723523338">
+<g id="2125692710">
 <rect x="608" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="628" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="649" y1="76" x2="669" y2="76" class="rail"/>
 <polygon points="656,73 662,76 656,79" class="arrow"/>
-<g id="2138500522">
+<g id="391451333">
 <rect x="669" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="735" y="80" text-anchor="middle" class="nonterminal-text">ObjectExpression</text>
 </g>
 <line x1="801" y1="76" x2="821" y2="76" class="rail"/>
 <polygon points="808,73 814,76 808,79" class="arrow"/>
-<g id="353639839">
+<g id="1662738762">
 <rect x="821" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="841" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ObjectReturnType.svg
+++ b/docs/railroad/TinyExpressionP4_ObjectReturnType.svg
@@ -14,7 +14,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1141954530">
+<g id="1869074818">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'object'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ObjectSetter.svg
+++ b/docs/railroad/TinyExpressionP4_ObjectSetter.svg
@@ -14,28 +14,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="850068028">
-<g id="986770686">
+<g id="1976569577">
+<g id="945494350">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="2106463177">
-<g id="1121484914">
-<g id="1954112018">
+<g id="814209200">
+<g id="1097849472">
+<g id="1585832846">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="671167303">
+<g id="1488564286">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="2136089722">
+<g id="555628164">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -50,7 +50,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="1546947636">
+<g id="623552222">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">ObjectExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ObjectTypeHint.svg
+++ b/docs/railroad/TinyExpressionP4_ObjectTypeHint.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="815868484">
-<g id="1807543972">
-<g id="1021349328">
+<g id="786721688">
+<g id="848224030">
+<g id="2126977075">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -30,7 +30,7 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="2012675831">
+<g id="1122215374">
 <rect x="140" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="178" y="80" text-anchor="middle" class="terminal-text">'object'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ObjectVariableDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_ObjectVariableDeclaration.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="157051325">
-<g id="2015175199">
-<g id="131798826">
+<g id="846201387">
+<g id="189191722">
+<g id="1128002489">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -24,7 +24,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="808264238">
+<g id="2115405268">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -37,20 +37,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1022288766">
+<g id="838251264">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="1695259295">
+<g id="2072291535">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="166350082">
-<g id="1947681275">
+<g id="177678338">
+<g id="1179571731">
 <rect x="369" y="62" width="118" height="28" class="nonterminal-box"/>
 <text x="428" y="80" text-anchor="middle" class="nonterminal-text">ObjectTypeHint</text>
 </g>
@@ -64,8 +64,8 @@
 </g>
 <line x1="503" y1="76" x2="523" y2="76" class="rail"/>
 <polygon points="510,73 516,76 510,79" class="arrow"/>
-<g id="2066878453">
-<g id="1121237586">
+<g id="1356986163">
+<g id="243131619">
 <rect x="539" y="62" width="104" height="28" class="nonterminal-box"/>
 <text x="591" y="80" text-anchor="middle" class="nonterminal-text">ObjectSetter</text>
 </g>
@@ -79,13 +79,13 @@
 </g>
 <line x1="659" y1="76" x2="679" y2="76" class="rail"/>
 <polygon points="666,73 672,76 666,79" class="arrow"/>
-<g id="904167921">
+<g id="1613712754">
 <rect x="679" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="727" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="776" y1="76" x2="796" y2="76" class="rail"/>
 <polygon points="783,73 789,76 783,79" class="arrow"/>
-<g id="1857898514">
+<g id="1405857357">
 <rect x="796" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="816" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ParenthesizedStringExpression.svg
+++ b/docs/railroad/TinyExpressionP4_ParenthesizedStringExpression.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ParenthesizedStringExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1438846034">
-<g id="185500100">
+<g id="404888284">
+<g id="767381765">
 <rect x="40" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="81" y1="58" x2="101" y2="58" class="rail"/>
 <polygon points="88,55 94,58 88,61" class="arrow"/>
-<g id="1211998570">
+<g id="2091336274">
 <rect x="101" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="233" y1="58" x2="253" y2="58" class="rail"/>
 <polygon points="240,55 246,58 240,61" class="arrow"/>
-<g id="31595484">
+<g id="730679780">
 <rect x="253" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="273" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_PowFunction.svg
+++ b/docs/railroad/TinyExpressionP4_PowFunction.svg
@@ -14,38 +14,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">PowFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="414847023">
-<g id="1012614741">
+<g id="1444267267">
+<g id="1896428595">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'pow'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1929701875">
+<g id="1188927908">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1188679479">
+<g id="1713623969">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="570582149">
+<g id="1014566707">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="383" y1="58" x2="403" y2="58" class="rail"/>
 <polygon points="390,55 396,58 390,61" class="arrow"/>
-<g id="1150150526">
+<g id="73993251">
 <rect x="403" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="476" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="549" y1="58" x2="569" y2="58" class="rail"/>
 <polygon points="556,55 562,58 556,61" class="arrow"/>
-<g id="269665645">
+<g id="777237939">
 <rect x="569" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="589" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_RandomFunction.svg
+++ b/docs/railroad/TinyExpressionP4_RandomFunction.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">RandomFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1497339865">
-<g id="1749166382">
+<g id="944993594">
+<g id="711695177">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'random'</text>
 </g>
 <line x1="116" y1="58" x2="136" y2="58" class="rail"/>
 <polygon points="123,55 129,58 123,61" class="arrow"/>
-<g id="977689218">
+<g id="1861001571">
 <rect x="136" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="177" y1="58" x2="197" y2="58" class="rail"/>
 <polygon points="184,55 190,58 184,61" class="arrow"/>
-<g id="1195344948">
+<g id="517182272">
 <rect x="197" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="217" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ReturnType.svg
+++ b/docs/railroad/TinyExpressionP4_ReturnType.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="948280510">
-<g id="887333586">
+<g id="1806700666">
+<g id="1193643817">
 <rect x="59" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="125" y="62" text-anchor="middle" class="nonterminal-text">NumberReturnType</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="191" y1="58" x2="195" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="195" y1="58" x2="211" y2="58" class="rail"/>
-<g id="501209032">
+<g id="1249130007">
 <rect x="59" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="125" y="100" text-anchor="middle" class="nonterminal-text">StringReturnType</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M195,96 Q203,96 203,88" class="rail" fill="none"/>
 <path d="M203,66 Q203,58 211,58" class="rail" fill="none"/>
-<g id="1395931942">
+<g id="1371388912">
 <rect x="56" y="120" width="139" height="28" class="nonterminal-box"/>
 <text x="125" y="138" text-anchor="middle" class="nonterminal-text">BooleanReturnType</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M195,134 Q203,134 203,126" class="rail" fill="none"/>
 <path d="M203,66 Q203,58 211,58" class="rail" fill="none"/>
-<g id="299452773">
+<g id="8887172">
 <rect x="59" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="125" y="176" text-anchor="middle" class="nonterminal-text">ObjectReturnType</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_RoundFunction.svg
+++ b/docs/railroad/TinyExpressionP4_RoundFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">RoundFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1402824802">
-<g id="1760870641">
+<g id="1930730172">
+<g id="223812727">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'round'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1785620496">
+<g id="1443980662">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1806962502">
+<g id="1683782377">
 <rect x="190" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="488689791">
+<g id="1184203453">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_SinFunction.svg
+++ b/docs/railroad/TinyExpressionP4_SinFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SinFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="803187653">
-<g id="2103243864">
+<g id="81403139">
+<g id="595581953">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'sin'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="399965753">
+<g id="845567125">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="330158693">
+<g id="1453256774">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="901478174">
+<g id="1494765045">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_SliceBaseExpression.svg
+++ b/docs/railroad/TinyExpressionP4_SliceBaseExpression.svg
@@ -14,51 +14,51 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceBaseExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="657932075">
-<g id="1872375138">
-<g id="1306880421">
+<g id="160823881">
+<g id="819590990">
+<g id="116736572">
 <rect x="56" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="125" y="62" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="195" y1="58" x2="215" y2="58" class="rail"/>
 <polygon points="202,55 208,58 202,61" class="arrow"/>
-<g id="332833498">
+<g id="1211910392">
 <rect x="215" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="235" y="62" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="256" y1="58" x2="276" y2="58" class="rail"/>
 <polygon points="263,55 269,58 263,61" class="arrow"/>
-<g id="739768324">
+<g id="664948809">
 <rect x="276" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="342" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="408" y1="58" x2="428" y2="58" class="rail"/>
 <polygon points="415,55 421,58 415,61" class="arrow"/>
-<g id="759910055">
+<g id="1839888355">
 <rect x="428" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="448" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="469" y1="58" x2="489" y2="58" class="rail"/>
 <polygon points="476,55 482,58 476,61" class="arrow"/>
-<g id="1258664682">
+<g id="1096953032">
 <rect x="489" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="555" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="621" y1="58" x2="641" y2="58" class="rail"/>
 <polygon points="628,55 634,58 628,61" class="arrow"/>
-<g id="1843595554">
+<g id="1806944148">
 <rect x="641" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="661" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="682" y1="58" x2="702" y2="58" class="rail"/>
 <polygon points="689,55 695,58 689,61" class="arrow"/>
-<g id="2124876610">
+<g id="1587999411">
 <rect x="702" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="768" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="834" y1="58" x2="854" y2="58" class="rail"/>
 <polygon points="841,55 847,58 841,61" class="arrow"/>
-<g id="158227527">
+<g id="1611498475">
 <rect x="854" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="874" y="62" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -67,38 +67,38 @@
 <line x1="895" y1="58" x2="895" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="895" y1="58" x2="911" y2="58" class="rail"/>
-<g id="1803991339">
-<g id="440767402">
+<g id="2018110225">
+<g id="1168316838">
 <rect x="162" y="82" width="139" height="28" class="nonterminal-box"/>
 <text x="231" y="100" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="301" y1="96" x2="321" y2="96" class="rail"/>
 <polygon points="308,93 314,96 308,99" class="arrow"/>
-<g id="1551791803">
+<g id="754538699">
 <rect x="321" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="341" y="100" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="362" y1="96" x2="382" y2="96" class="rail"/>
 <polygon points="369,93 375,96 369,99" class="arrow"/>
-<g id="663323927">
+<g id="543655012">
 <rect x="382" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="448" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="514" y1="96" x2="534" y2="96" class="rail"/>
 <polygon points="521,93 527,96 521,99" class="arrow"/>
-<g id="432430521">
+<g id="1610310817">
 <rect x="534" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="554" y="100" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="575" y1="96" x2="595" y2="96" class="rail"/>
 <polygon points="582,93 588,96 582,99" class="arrow"/>
-<g id="791168488">
+<g id="38287569">
 <rect x="595" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="661" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="727" y1="96" x2="747" y2="96" class="rail"/>
 <polygon points="734,93 740,96 734,99" class="arrow"/>
-<g id="13378840">
+<g id="1678837587">
 <rect x="747" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="767" y="100" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -109,44 +109,44 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M895,96 Q903,96 903,88" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="2080392919">
-<g id="1082530423">
+<g id="1253396039">
+<g id="2090030805">
 <rect x="132" y="120" width="139" height="28" class="nonterminal-box"/>
 <text x="201" y="138" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="271" y1="134" x2="291" y2="134" class="rail"/>
 <polygon points="278,131 284,134 278,137" class="arrow"/>
-<g id="770441354">
+<g id="1063151398">
 <rect x="291" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="311" y="138" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="332" y1="134" x2="352" y2="134" class="rail"/>
 <polygon points="339,131 345,134 339,137" class="arrow"/>
-<g id="1281955018">
+<g id="1402590209">
 <rect x="352" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="418" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="484" y1="134" x2="504" y2="134" class="rail"/>
 <polygon points="491,131 497,134 491,137" class="arrow"/>
-<g id="318284685">
+<g id="1690287104">
 <rect x="504" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="524" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="545" y1="134" x2="565" y2="134" class="rail"/>
 <polygon points="552,131 558,134 552,137" class="arrow"/>
-<g id="1650284039">
+<g id="41712572">
 <rect x="565" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="585" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="606" y1="134" x2="626" y2="134" class="rail"/>
 <polygon points="613,131 619,134 613,137" class="arrow"/>
-<g id="796455574">
+<g id="1322732418">
 <rect x="626" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="692" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="758" y1="134" x2="778" y2="134" class="rail"/>
 <polygon points="765,131 771,134 765,137" class="arrow"/>
-<g id="724794615">
+<g id="1408481157">
 <rect x="778" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="798" y="138" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -157,32 +157,32 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M895,134 Q903,134 903,126" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="528898437">
-<g id="1961216574">
+<g id="2071232307">
+<g id="737504566">
 <rect x="238" y="158" width="139" height="28" class="nonterminal-box"/>
 <text x="307" y="176" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="377" y1="172" x2="397" y2="172" class="rail"/>
 <polygon points="384,169 390,172 384,175" class="arrow"/>
-<g id="484534902">
+<g id="1594538129">
 <rect x="397" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="417" y="176" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="438" y1="172" x2="458" y2="172" class="rail"/>
 <polygon points="445,169 451,172 445,175" class="arrow"/>
-<g id="738552281">
+<g id="285959018">
 <rect x="458" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="524" y="176" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="590" y1="172" x2="610" y2="172" class="rail"/>
 <polygon points="597,169 603,172 597,175" class="arrow"/>
-<g id="1380824176">
+<g id="1907150970">
 <rect x="610" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="630" y="176" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="651" y1="172" x2="671" y2="172" class="rail"/>
 <polygon points="658,169 664,172 658,175" class="arrow"/>
-<g id="144908349">
+<g id="1907400612">
 <rect x="671" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="691" y="176" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -193,44 +193,44 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M895,172 Q903,172 903,164" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1048521843">
-<g id="407547917">
+<g id="779910007">
+<g id="825115396">
 <rect x="132" y="196" width="139" height="28" class="nonterminal-box"/>
 <text x="201" y="214" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="271" y1="210" x2="291" y2="210" class="rail"/>
 <polygon points="278,207 284,210 278,213" class="arrow"/>
-<g id="656111936">
+<g id="639007323">
 <rect x="291" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="311" y="214" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="332" y1="210" x2="352" y2="210" class="rail"/>
 <polygon points="339,207 345,210 339,213" class="arrow"/>
-<g id="908597078">
+<g id="1395563650">
 <rect x="352" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="372" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="393" y1="210" x2="413" y2="210" class="rail"/>
 <polygon points="400,207 406,210 400,213" class="arrow"/>
-<g id="458177127">
+<g id="201059379">
 <rect x="413" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="479" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="545" y1="210" x2="565" y2="210" class="rail"/>
 <polygon points="552,207 558,210 552,213" class="arrow"/>
-<g id="1447574491">
+<g id="1208920107">
 <rect x="565" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="585" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="606" y1="210" x2="626" y2="210" class="rail"/>
 <polygon points="613,207 619,210 613,213" class="arrow"/>
-<g id="711301419">
+<g id="1574946771">
 <rect x="626" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="692" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="758" y1="210" x2="778" y2="210" class="rail"/>
 <polygon points="765,207 771,210 765,213" class="arrow"/>
-<g id="1543616918">
+<g id="2058521190">
 <rect x="778" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="798" y="214" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -241,32 +241,32 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M895,210 Q903,210 903,202" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1814718277">
-<g id="704532100">
+<g id="632992434">
+<g id="319738211">
 <rect x="238" y="234" width="139" height="28" class="nonterminal-box"/>
 <text x="307" y="252" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="377" y1="248" x2="397" y2="248" class="rail"/>
 <polygon points="384,245 390,248 384,251" class="arrow"/>
-<g id="802436689">
+<g id="810319246">
 <rect x="397" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="417" y="252" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="438" y1="248" x2="458" y2="248" class="rail"/>
 <polygon points="445,245 451,248 445,251" class="arrow"/>
-<g id="2118711092">
+<g id="1589846107">
 <rect x="458" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="478" y="252" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="499" y1="248" x2="519" y2="248" class="rail"/>
 <polygon points="506,245 512,248 506,251" class="arrow"/>
-<g id="957567034">
+<g id="321474359">
 <rect x="519" y="234" width="132" height="28" class="nonterminal-box"/>
 <text x="585" y="252" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="651" y1="248" x2="671" y2="248" class="rail"/>
 <polygon points="658,245 664,248 658,251" class="arrow"/>
-<g id="1656927218">
+<g id="1984496120">
 <rect x="671" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="691" y="252" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -277,38 +277,38 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M895,248 Q903,248 903,240" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1495052294">
-<g id="1440930979">
+<g id="156617115">
+<g id="1648140198">
 <rect x="208" y="272" width="139" height="28" class="nonterminal-box"/>
 <text x="277" y="290" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="347" y1="286" x2="367" y2="286" class="rail"/>
 <polygon points="354,283 360,286 354,289" class="arrow"/>
-<g id="1993594021">
+<g id="993338401">
 <rect x="367" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="387" y="290" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="408" y1="286" x2="428" y2="286" class="rail"/>
 <polygon points="415,283 421,286 415,289" class="arrow"/>
-<g id="33137838">
+<g id="97367166">
 <rect x="428" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="448" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="469" y1="286" x2="489" y2="286" class="rail"/>
 <polygon points="476,283 482,286 476,289" class="arrow"/>
-<g id="1045887899">
+<g id="1972549975">
 <rect x="489" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="509" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="530" y1="286" x2="550" y2="286" class="rail"/>
 <polygon points="537,283 543,286 537,289" class="arrow"/>
-<g id="2106732342">
+<g id="1935006188">
 <rect x="550" y="272" width="132" height="28" class="nonterminal-box"/>
 <text x="616" y="290" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="682" y1="286" x2="702" y2="286" class="rail"/>
 <polygon points="689,283 695,286 689,289" class="arrow"/>
-<g id="353151709">
+<g id="1632890763">
 <rect x="702" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="722" y="290" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -319,26 +319,26 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M895,286 Q903,286 903,278" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1488034126">
-<g id="1352602269">
+<g id="1747117589">
+<g id="1777177063">
 <rect x="314" y="310" width="139" height="28" class="nonterminal-box"/>
 <text x="383" y="328" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="453" y1="324" x2="473" y2="324" class="rail"/>
 <polygon points="460,321 466,324 460,327" class="arrow"/>
-<g id="1016622119">
+<g id="883601295">
 <rect x="473" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="493" y="328" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="514" y1="324" x2="534" y2="324" class="rail"/>
 <polygon points="521,321 527,324 521,327" class="arrow"/>
-<g id="1278370603">
+<g id="1249587494">
 <rect x="534" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="554" y="328" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="575" y1="324" x2="595" y2="324" class="rail"/>
 <polygon points="582,321 588,324 582,327" class="arrow"/>
-<g id="1880258091">
+<g id="1841635555">
 <rect x="595" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="615" y="328" text-anchor="middle" class="terminal-text">']'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_SliceBaseReceiver.svg
+++ b/docs/railroad/TinyExpressionP4_SliceBaseReceiver.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceBaseReceiver</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2037323343">
-<g id="1850064323">
+<g id="839850431">
+<g id="444698616">
 <rect x="73" y="44" width="188" height="28" class="nonterminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="nonterminal-text">ExternalStringInvocation</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="261" y1="58" x2="279" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="279" y1="58" x2="295" y2="58" class="rail"/>
-<g id="2132382637">
+<g id="134933833">
 <rect x="56" y="82" width="223" height="28" class="nonterminal-box"/>
 <text x="167" y="100" text-anchor="middle" class="nonterminal-text">ParenthesizedStringExpression</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M279,96 Q287,96 287,88" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="243334059">
+<g id="1899831639">
 <rect x="91" y="120" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="138" text-anchor="middle" class="nonterminal-text">ToUpperCaseFunction</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M279,134 Q287,134 287,126" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1050910936">
+<g id="315160306">
 <rect x="91" y="158" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="176" text-anchor="middle" class="nonterminal-text">ToLowerCaseFunction</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M279,172 Q287,172 287,164" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="2102110570">
+<g id="69223708">
 <rect x="115" y="196" width="104" height="28" class="nonterminal-box"/>
 <text x="167" y="214" text-anchor="middle" class="nonterminal-text">TrimFunction</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M279,210 Q287,210 287,202" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1325193621">
+<g id="1537179764">
 <rect x="87" y="234" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="252" text-anchor="middle" class="nonterminal-text">ToUpperCaseDotMethod</text>
 </g>
@@ -73,7 +73,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M279,248 Q287,248 287,240" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1202204226">
+<g id="1135621577">
 <rect x="87" y="272" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="290" text-anchor="middle" class="nonterminal-text">ToLowerCaseDotMethod</text>
 </g>
@@ -83,7 +83,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M279,286 Q287,286 287,278" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1680794383">
+<g id="379204651">
 <rect x="112" y="310" width="111" height="28" class="nonterminal-box"/>
 <text x="167" y="328" text-anchor="middle" class="nonterminal-text">TrimDotMethod</text>
 </g>
@@ -93,7 +93,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M279,324 Q287,324 287,316" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1141773849">
+<g id="278170433">
 <rect x="136" y="348" width="62" height="28" class="nonterminal-box"/>
 <text x="167" y="366" text-anchor="middle" class="nonterminal-text">STRING</text>
 </g>
@@ -103,7 +103,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M279,362 Q287,362 287,354" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1821794172">
+<g id="925836551">
 <rect x="119" y="386" width="97" height="28" class="nonterminal-box"/>
 <text x="167" y="404" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -113,7 +113,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M279,400 Q287,400 287,392" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1783277202">
+<g id="1970491478">
 <rect x="101" y="424" width="132" height="28" class="nonterminal-box"/>
 <text x="167" y="442" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_SliceExpression.svg
+++ b/docs/railroad/TinyExpressionP4_SliceExpression.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1300617554">
-<g id="1998940153">
+<g id="165469024">
+<g id="1464422449">
 <rect x="56" y="44" width="167" height="28" class="nonterminal-box"/>
 <text x="139" y="62" text-anchor="middle" class="nonterminal-text">SliceNestedExpression</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="223" y1="58" x2="223" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="223" y1="58" x2="239" y2="58" class="rail"/>
-<g id="1581989204">
+<g id="6547689">
 <rect x="63" y="82" width="153" height="28" class="nonterminal-box"/>
 <text x="139" y="100" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_SliceNestedExpression.svg
+++ b/docs/railroad/TinyExpressionP4_SliceNestedExpression.svg
@@ -14,51 +14,51 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceNestedExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="920397781">
-<g id="467125220">
-<g id="2026056669">
+<g id="781534635">
+<g id="1880115448">
+<g id="443816028">
 <rect x="56" y="44" width="153" height="28" class="nonterminal-box"/>
 <text x="132" y="62" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="209" y1="58" x2="229" y2="58" class="rail"/>
 <polygon points="216,55 222,58 216,61" class="arrow"/>
-<g id="453228992">
+<g id="1592979913">
 <rect x="229" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="270" y1="58" x2="290" y2="58" class="rail"/>
 <polygon points="277,55 283,58 277,61" class="arrow"/>
-<g id="1336686599">
+<g id="555726412">
 <rect x="290" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="356" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="422" y1="58" x2="442" y2="58" class="rail"/>
 <polygon points="429,55 435,58 429,61" class="arrow"/>
-<g id="1375508670">
+<g id="125716372">
 <rect x="442" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="462" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="483" y1="58" x2="503" y2="58" class="rail"/>
 <polygon points="490,55 496,58 490,61" class="arrow"/>
-<g id="813751455">
+<g id="1039272415">
 <rect x="503" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="569" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="635" y1="58" x2="655" y2="58" class="rail"/>
 <polygon points="642,55 648,58 642,61" class="arrow"/>
-<g id="919318262">
+<g id="1959250705">
 <rect x="655" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="675" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="696" y1="58" x2="716" y2="58" class="rail"/>
 <polygon points="703,55 709,58 703,61" class="arrow"/>
-<g id="411685928">
+<g id="683064851">
 <rect x="716" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="782" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="848" y1="58" x2="868" y2="58" class="rail"/>
 <polygon points="855,55 861,58 855,61" class="arrow"/>
-<g id="763729647">
+<g id="1560350326">
 <rect x="868" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="888" y="62" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -67,38 +67,38 @@
 <line x1="909" y1="58" x2="909" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="909" y1="58" x2="925" y2="58" class="rail"/>
-<g id="1856680297">
-<g id="1887466102">
+<g id="2098676375">
+<g id="986024616">
 <rect x="162" y="82" width="153" height="28" class="nonterminal-box"/>
 <text x="238" y="100" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="315" y1="96" x2="335" y2="96" class="rail"/>
 <polygon points="322,93 328,96 322,99" class="arrow"/>
-<g id="645841114">
+<g id="664731077">
 <rect x="335" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="100" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="376" y1="96" x2="396" y2="96" class="rail"/>
 <polygon points="383,93 389,96 383,99" class="arrow"/>
-<g id="667748372">
+<g id="1924736510">
 <rect x="396" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="462" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="528" y1="96" x2="548" y2="96" class="rail"/>
 <polygon points="535,93 541,96 535,99" class="arrow"/>
-<g id="35661802">
+<g id="10282201">
 <rect x="548" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="568" y="100" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="589" y1="96" x2="609" y2="96" class="rail"/>
 <polygon points="596,93 602,96 596,99" class="arrow"/>
-<g id="1900082714">
+<g id="379236008">
 <rect x="609" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="675" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="741" y1="96" x2="761" y2="96" class="rail"/>
 <polygon points="748,93 754,96 748,99" class="arrow"/>
-<g id="560500984">
+<g id="1186597227">
 <rect x="761" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="781" y="100" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -109,44 +109,44 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M909,96 Q917,96 917,88" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="1761080451">
-<g id="1840698401">
+<g id="1266289973">
+<g id="449502144">
 <rect x="132" y="120" width="153" height="28" class="nonterminal-box"/>
 <text x="208" y="138" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="285" y1="134" x2="305" y2="134" class="rail"/>
 <polygon points="292,131 298,134 292,137" class="arrow"/>
-<g id="456134571">
+<g id="1508301279">
 <rect x="305" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="325" y="138" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="346" y1="134" x2="366" y2="134" class="rail"/>
 <polygon points="353,131 359,134 353,137" class="arrow"/>
-<g id="2126164837">
+<g id="1333879513">
 <rect x="366" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="432" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="498" y1="134" x2="518" y2="134" class="rail"/>
 <polygon points="505,131 511,134 505,137" class="arrow"/>
-<g id="1168139298">
+<g id="138777156">
 <rect x="518" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="538" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="559" y1="134" x2="579" y2="134" class="rail"/>
 <polygon points="566,131 572,134 566,137" class="arrow"/>
-<g id="510437227">
+<g id="1142770775">
 <rect x="579" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="599" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="620" y1="134" x2="640" y2="134" class="rail"/>
 <polygon points="627,131 633,134 627,137" class="arrow"/>
-<g id="96120410">
+<g id="735730986">
 <rect x="640" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="706" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="772" y1="134" x2="792" y2="134" class="rail"/>
 <polygon points="779,131 785,134 779,137" class="arrow"/>
-<g id="774902803">
+<g id="1862886690">
 <rect x="792" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="812" y="138" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -157,32 +157,32 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M909,134 Q917,134 917,126" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="794180817">
-<g id="324747529">
+<g id="194748833">
+<g id="1697357817">
 <rect x="238" y="158" width="153" height="28" class="nonterminal-box"/>
 <text x="314" y="176" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="391" y1="172" x2="411" y2="172" class="rail"/>
 <polygon points="398,169 404,172 398,175" class="arrow"/>
-<g id="1128527174">
+<g id="484556155">
 <rect x="411" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="431" y="176" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="452" y1="172" x2="472" y2="172" class="rail"/>
 <polygon points="459,169 465,172 459,175" class="arrow"/>
-<g id="1845359025">
+<g id="954592176">
 <rect x="472" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="538" y="176" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="604" y1="172" x2="624" y2="172" class="rail"/>
 <polygon points="611,169 617,172 611,175" class="arrow"/>
-<g id="989418337">
+<g id="602757692">
 <rect x="624" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="644" y="176" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="665" y1="172" x2="685" y2="172" class="rail"/>
 <polygon points="672,169 678,172 672,175" class="arrow"/>
-<g id="1935875646">
+<g id="444653039">
 <rect x="685" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="705" y="176" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -193,44 +193,44 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M909,172 Q917,172 917,164" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="664998549">
-<g id="757342451">
+<g id="762114897">
+<g id="473195273">
 <rect x="132" y="196" width="153" height="28" class="nonterminal-box"/>
 <text x="208" y="214" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="285" y1="210" x2="305" y2="210" class="rail"/>
 <polygon points="292,207 298,210 292,213" class="arrow"/>
-<g id="1563823213">
+<g id="1430386185">
 <rect x="305" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="325" y="214" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="346" y1="210" x2="366" y2="210" class="rail"/>
 <polygon points="353,207 359,210 353,213" class="arrow"/>
-<g id="919563035">
+<g id="1236412139">
 <rect x="366" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="386" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="407" y1="210" x2="427" y2="210" class="rail"/>
 <polygon points="414,207 420,210 414,213" class="arrow"/>
-<g id="677476775">
+<g id="527569109">
 <rect x="427" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="493" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="559" y1="210" x2="579" y2="210" class="rail"/>
 <polygon points="566,207 572,210 566,213" class="arrow"/>
-<g id="617543648">
+<g id="543233049">
 <rect x="579" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="599" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="620" y1="210" x2="640" y2="210" class="rail"/>
 <polygon points="627,207 633,210 627,213" class="arrow"/>
-<g id="1240908400">
+<g id="2051694498">
 <rect x="640" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="706" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="772" y1="210" x2="792" y2="210" class="rail"/>
 <polygon points="779,207 785,210 779,213" class="arrow"/>
-<g id="78442470">
+<g id="571980670">
 <rect x="792" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="812" y="214" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -241,32 +241,32 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M909,210 Q917,210 917,202" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="2111718832">
-<g id="1954648182">
+<g id="805257874">
+<g id="92666681">
 <rect x="238" y="234" width="153" height="28" class="nonterminal-box"/>
 <text x="314" y="252" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="391" y1="248" x2="411" y2="248" class="rail"/>
 <polygon points="398,245 404,248 398,251" class="arrow"/>
-<g id="194722260">
+<g id="765072228">
 <rect x="411" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="431" y="252" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="452" y1="248" x2="472" y2="248" class="rail"/>
 <polygon points="459,245 465,248 459,251" class="arrow"/>
-<g id="1756046494">
+<g id="852070882">
 <rect x="472" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="492" y="252" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="513" y1="248" x2="533" y2="248" class="rail"/>
 <polygon points="520,245 526,248 520,251" class="arrow"/>
-<g id="1470342308">
+<g id="2029324945">
 <rect x="533" y="234" width="132" height="28" class="nonterminal-box"/>
 <text x="599" y="252" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="665" y1="248" x2="685" y2="248" class="rail"/>
 <polygon points="672,245 678,248 672,251" class="arrow"/>
-<g id="802786310">
+<g id="1375955589">
 <rect x="685" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="705" y="252" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -277,38 +277,38 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M909,248 Q917,248 917,240" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="359582609">
-<g id="1281364289">
+<g id="1228145336">
+<g id="1363640334">
 <rect x="208" y="272" width="153" height="28" class="nonterminal-box"/>
 <text x="284" y="290" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="361" y1="286" x2="381" y2="286" class="rail"/>
 <polygon points="368,283 374,286 368,289" class="arrow"/>
-<g id="111942381">
+<g id="20363573">
 <rect x="381" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="401" y="290" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="422" y1="286" x2="442" y2="286" class="rail"/>
 <polygon points="429,283 435,286 429,289" class="arrow"/>
-<g id="1710628738">
+<g id="1219013844">
 <rect x="442" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="462" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="483" y1="286" x2="503" y2="286" class="rail"/>
 <polygon points="490,283 496,286 490,289" class="arrow"/>
-<g id="1787442505">
+<g id="496405633">
 <rect x="503" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="523" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="544" y1="286" x2="564" y2="286" class="rail"/>
 <polygon points="551,283 557,286 551,289" class="arrow"/>
-<g id="640469824">
+<g id="1882994893">
 <rect x="564" y="272" width="132" height="28" class="nonterminal-box"/>
 <text x="630" y="290" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="696" y1="286" x2="716" y2="286" class="rail"/>
 <polygon points="703,283 709,286 703,289" class="arrow"/>
-<g id="1077003802">
+<g id="1148700910">
 <rect x="716" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="736" y="290" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -319,26 +319,26 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M909,286 Q917,286 917,278" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="1099582189">
-<g id="779457544">
+<g id="2032014608">
+<g id="1617915291">
 <rect x="314" y="310" width="153" height="28" class="nonterminal-box"/>
 <text x="390" y="328" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="467" y1="324" x2="487" y2="324" class="rail"/>
 <polygon points="474,321 480,324 474,327" class="arrow"/>
-<g id="1849896013">
+<g id="1904528139">
 <rect x="487" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="507" y="328" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="528" y1="324" x2="548" y2="324" class="rail"/>
 <polygon points="535,321 541,324 535,327" class="arrow"/>
-<g id="546059913">
+<g id="189681005">
 <rect x="548" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="568" y="328" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="589" y1="324" x2="609" y2="324" class="rail"/>
 <polygon points="596,321 602,324 596,327" class="arrow"/>
-<g id="1138578250">
+<g id="1644609406">
 <rect x="609" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="629" y="328" text-anchor="middle" class="terminal-text">']'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_SqrtFunction.svg
+++ b/docs/railroad/TinyExpressionP4_SqrtFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SqrtFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="289966311">
-<g id="1890638923">
+<g id="1843390800">
+<g id="1184203334">
 <rect x="40" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="71" y="62" text-anchor="middle" class="terminal-text">'sqrt'</text>
 </g>
 <line x1="102" y1="58" x2="122" y2="58" class="rail"/>
 <polygon points="109,55 115,58 109,61" class="arrow"/>
-<g id="1556524176">
+<g id="1088218061">
 <rect x="122" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="142" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="163" y1="58" x2="183" y2="58" class="rail"/>
 <polygon points="170,55 176,58 170,61" class="arrow"/>
-<g id="1818285489">
+<g id="1746506049">
 <rect x="183" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="1735148229">
+<g id="120773698">
 <rect x="349" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="369" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StartsWithDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_StartsWithDotMethod.svg
@@ -14,32 +14,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StartsWithDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="215960248">
-<g id="783752254">
+<g id="486211780">
+<g id="1122692078">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="1503392902">
+<g id="904931919">
 <rect x="157" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="212" y="62" text-anchor="middle" class="terminal-text">'.startsWith'</text>
 </g>
 <line x1="268" y1="58" x2="288" y2="58" class="rail"/>
 <polygon points="275,55 281,58 275,61" class="arrow"/>
-<g id="764278383">
+<g id="303595196">
 <rect x="288" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="308" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="472259056">
+<g id="1028512792">
 <rect x="349" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="415" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="481" y1="58" x2="501" y2="58" class="rail"/>
 <polygon points="488,55 494,58 488,61" class="arrow"/>
-<g id="182886566">
+<g id="686679492">
 <rect x="501" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="521" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StartsWithFunction.svg
+++ b/docs/railroad/TinyExpressionP4_StartsWithFunction.svg
@@ -14,38 +14,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StartsWithFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="278447004">
-<g id="1481214758">
+<g id="1967624519">
+<g id="287896198">
 <rect x="40" y="44" width="104" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="92" y="62" text-anchor="middle" class="terminal-text">'startsWith'</text>
 </g>
 <line x1="144" y1="58" x2="164" y2="58" class="rail"/>
 <polygon points="151,55 157,58 151,61" class="arrow"/>
-<g id="2140893968">
+<g id="1908422909">
 <rect x="164" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="184" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="205" y1="58" x2="225" y2="58" class="rail"/>
 <polygon points="212,55 218,58 212,61" class="arrow"/>
-<g id="633565221">
+<g id="509217327">
 <rect x="225" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="291" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="357" y1="58" x2="377" y2="58" class="rail"/>
 <polygon points="364,55 370,58 364,61" class="arrow"/>
-<g id="516392387">
+<g id="496979150">
 <rect x="377" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="397" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="418" y1="58" x2="438" y2="58" class="rail"/>
 <polygon points="425,55 431,58 425,61" class="arrow"/>
-<g id="180563334">
+<g id="1274360121">
 <rect x="438" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="504" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="570" y1="58" x2="590" y2="58" class="rail"/>
 <polygon points="577,55 583,58 577,61" class="arrow"/>
-<g id="786750525">
+<g id="998440810">
 <rect x="590" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="610" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringCase.svg
+++ b/docs/railroad/TinyExpressionP4_StringCase.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="185399334">
-<g id="490934263">
+<g id="1394653037">
+<g id="1669509992">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="1877443329">
+<g id="1772942027">
 <rect x="199" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="223" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="2005565987">
+<g id="1411316798">
 <rect x="267" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="329" y="62" text-anchor="middle" class="nonterminal-text">StringCaseValue</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringCaseValue.svg
+++ b/docs/railroad/TinyExpressionP4_StringCaseValue.svg
@@ -14,7 +14,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringCaseValue</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="922774118">
+<g id="21389097">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringComparisonExpression.svg
+++ b/docs/railroad/TinyExpressionP4_StringComparisonExpression.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringComparisonExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1747084960">
-<g id="1833876244">
+<g id="1993067365">
+<g id="943303444">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="1956725548">
+<g id="2146141489">
 <rect x="192" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="62" text-anchor="middle" class="nonterminal-text">EqualityOp</text>
 </g>
 <line x1="282" y1="58" x2="302" y2="58" class="rail"/>
 <polygon points="289,55 295,58 289,61" class="arrow"/>
-<g id="359743536">
+<g id="250523159">
 <rect x="302" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="368" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringDefaultCase.svg
+++ b/docs/railroad/TinyExpressionP4_StringDefaultCase.svg
@@ -14,20 +14,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringDefaultCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="301995899">
-<g id="238379527">
+<g id="1592422561">
+<g id="625956754">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'default'</text>
 </g>
 <line x1="123" y1="58" x2="143" y2="58" class="rail"/>
 <polygon points="130,55 136,58 130,61" class="arrow"/>
-<g id="1561921355">
+<g id="737919834">
 <rect x="143" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="2116095313">
+<g id="136783127">
 <rect x="211" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="273" y="62" text-anchor="middle" class="nonterminal-text">StringCaseValue</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringExpression.svg
+++ b/docs/railroad/TinyExpressionP4_StringExpression.svg
@@ -14,22 +14,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1264837328">
-<g id="447786424">
+<g id="1426899475">
+<g id="224423917">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">StringTerm</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="1035900164">
-<g id="586953102">
-<g id="1182145464">
+<g id="1861693771">
+<g id="1617307053">
+<g id="280325800">
 <rect x="166" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="86" text-anchor="middle" class="terminal-text">'+'</text>
 </g>
 <line x1="207" y1="82" x2="227" y2="82" class="rail"/>
 <polygon points="214,79 220,82 214,85" class="arrow"/>
-<g id="1095778239">
+<g id="252639479">
 <rect x="227" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="272" y="86" text-anchor="middle" class="nonterminal-text">StringTerm</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringMatchExpression.svg
+++ b/docs/railroad/TinyExpressionP4_StringMatchExpression.svg
@@ -14,34 +14,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringMatchExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="847892074">
-<g id="1531029667">
+<g id="1190668344">
+<g id="98508726">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'match'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="288228842">
+<g id="2033472738">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="524716354">
+<g id="905879137">
 <rect x="190" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="235" y="62" text-anchor="middle" class="nonterminal-text">StringCase</text>
 </g>
 <line x1="280" y1="58" x2="300" y2="58" class="rail"/>
 <polygon points="287,55 293,58 287,61" class="arrow"/>
-<g id="1720795547">
-<g id="1303830006">
-<g id="2047092608">
+<g id="1658735474">
+<g id="588436711">
+<g id="92639715">
 <rect x="316" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="336" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="357" y1="82" x2="377" y2="82" class="rail"/>
 <polygon points="364,79 370,82 364,85" class="arrow"/>
-<g id="752258259">
+<g id="2019171402">
 <rect x="377" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="422" y="86" text-anchor="middle" class="nonterminal-text">StringCase</text>
 </g>
@@ -62,19 +62,19 @@
 </g>
 <line x1="483" y1="58" x2="503" y2="58" class="rail"/>
 <polygon points="490,55 496,58 490,61" class="arrow"/>
-<g id="1030902510">
+<g id="1274926147">
 <rect x="503" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="523" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="544" y1="58" x2="564" y2="58" class="rail"/>
 <polygon points="551,55 557,58 551,61" class="arrow"/>
-<g id="626712967">
+<g id="1668102458">
 <rect x="564" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="633" y="62" text-anchor="middle" class="nonterminal-text">StringDefaultCase</text>
 </g>
 <line x1="703" y1="58" x2="723" y2="58" class="rail"/>
 <polygon points="710,55 716,58 710,61" class="arrow"/>
-<g id="1593364919">
+<g id="1450015836">
 <rect x="723" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="743" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringMethodDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_StringMethodDeclaration.svg
@@ -14,27 +14,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1367004142">
-<g id="1065602123">
+<g id="1489509398">
+<g id="17850220">
 <rect x="40" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="80" text-anchor="middle" class="nonterminal-text">StringReturnType</text>
 </g>
 <line x1="172" y1="76" x2="192" y2="76" class="rail"/>
 <polygon points="179,73 185,76 179,79" class="arrow"/>
-<g id="1812168153">
+<g id="1763901668">
 <rect x="192" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="282" y1="76" x2="302" y2="76" class="rail"/>
 <polygon points="289,73 295,76 289,79" class="arrow"/>
-<g id="1235072108">
+<g id="823066911">
 <rect x="302" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="322" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="343" y1="76" x2="363" y2="76" class="rail"/>
 <polygon points="350,73 356,76 350,79" class="arrow"/>
-<g id="472956488">
-<g id="1039191081">
+<g id="78614975">
+<g id="130499860">
 <rect x="379" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="445" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -48,25 +48,25 @@
 </g>
 <line x1="527" y1="76" x2="547" y2="76" class="rail"/>
 <polygon points="534,73 540,76 534,79" class="arrow"/>
-<g id="1797973410">
+<g id="1979352558">
 <rect x="547" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="567" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="588" y1="76" x2="608" y2="76" class="rail"/>
 <polygon points="595,73 601,76 595,79" class="arrow"/>
-<g id="1336939135">
+<g id="1010066871">
 <rect x="608" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="628" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="649" y1="76" x2="669" y2="76" class="rail"/>
 <polygon points="656,73 662,76 656,79" class="arrow"/>
-<g id="1956253220">
+<g id="31877312">
 <rect x="669" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="735" y="80" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="801" y1="76" x2="821" y2="76" class="rail"/>
 <polygon points="808,73 814,76 808,79" class="arrow"/>
-<g id="1841376257">
+<g id="2033984298">
 <rect x="821" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="841" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringReturnType.svg
+++ b/docs/railroad/TinyExpressionP4_StringReturnType.svg
@@ -14,7 +14,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1050867440">
+<g id="57791927">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'string'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringSetter.svg
+++ b/docs/railroad/TinyExpressionP4_StringSetter.svg
@@ -14,28 +14,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1960953964">
-<g id="1110750478">
+<g id="84095450">
+<g id="1355668921">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="1210747160">
-<g id="897231330">
-<g id="1182231374">
+<g id="1221000562">
+<g id="44642337">
+<g id="1516374270">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="1788965023">
+<g id="1158780866">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="1384245881">
+<g id="1018630683">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -50,7 +50,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="703479050">
+<g id="18926639">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringTerm.svg
+++ b/docs/railroad/TinyExpressionP4_StringTerm.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringTerm</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1997439788">
-<g id="708618127">
+<g id="238447434">
+<g id="1599100324">
 <rect x="84" y="44" width="167" height="28" class="nonterminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="nonterminal-text">StringMatchExpression</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="251" y1="58" x2="279" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="279" y1="58" x2="295" y2="58" class="rail"/>
-<g id="254768467">
+<g id="421738958">
 <rect x="56" y="82" width="223" height="28" class="nonterminal-box"/>
 <text x="167" y="100" text-anchor="middle" class="nonterminal-text">ParenthesizedStringExpression</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M279,96 Q287,96 287,88" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="503489425">
+<g id="1478525287">
 <rect x="105" y="120" width="125" height="28" class="nonterminal-box"/>
 <text x="167" y="138" text-anchor="middle" class="nonterminal-text">SliceExpression</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M279,134 Q287,134 287,126" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1408142751">
+<g id="1356629061">
 <rect x="73" y="158" width="188" height="28" class="nonterminal-box"/>
 <text x="167" y="176" text-anchor="middle" class="nonterminal-text">ExternalStringInvocation</text>
 </g>
@@ -53,7 +53,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M279,172 Q287,172 287,164" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="480331954">
+<g id="234620559">
 <rect x="91" y="196" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="214" text-anchor="middle" class="nonterminal-text">ToUpperCaseFunction</text>
 </g>
@@ -63,7 +63,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M279,210 Q287,210 287,202" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1758475160">
+<g id="227652535">
 <rect x="91" y="234" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="252" text-anchor="middle" class="nonterminal-text">ToLowerCaseFunction</text>
 </g>
@@ -73,7 +73,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M279,248 Q287,248 287,240" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1665469240">
+<g id="1374036187">
 <rect x="115" y="272" width="104" height="28" class="nonterminal-box"/>
 <text x="167" y="290" text-anchor="middle" class="nonterminal-text">TrimFunction</text>
 </g>
@@ -83,7 +83,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M279,286 Q287,286 287,278" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1147199674">
+<g id="1705801742">
 <rect x="87" y="310" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="328" text-anchor="middle" class="nonterminal-text">ToUpperCaseDotMethod</text>
 </g>
@@ -93,7 +93,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M279,324 Q287,324 287,316" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1376965724">
+<g id="134861386">
 <rect x="87" y="348" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="366" text-anchor="middle" class="nonterminal-text">ToLowerCaseDotMethod</text>
 </g>
@@ -103,7 +103,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M279,362 Q287,362 287,354" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1001877877">
+<g id="142984439">
 <rect x="112" y="386" width="111" height="28" class="nonterminal-box"/>
 <text x="167" y="404" text-anchor="middle" class="nonterminal-text">TrimDotMethod</text>
 </g>
@@ -113,7 +113,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M279,400 Q287,400 287,392" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1885381104">
+<g id="1745214916">
 <rect x="136" y="424" width="62" height="28" class="nonterminal-box"/>
 <text x="167" y="442" text-anchor="middle" class="nonterminal-text">STRING</text>
 </g>
@@ -123,7 +123,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M279,438 Q287,438 287,430" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="860285558">
+<g id="1861203138">
 <rect x="119" y="462" width="97" height="28" class="nonterminal-box"/>
 <text x="167" y="480" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -133,7 +133,7 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M279,476 Q287,476 287,468" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="2008184950">
+<g id="682799319">
 <rect x="101" y="500" width="132" height="28" class="nonterminal-box"/>
 <text x="167" y="518" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringTypeHint.svg
+++ b/docs/railroad/TinyExpressionP4_StringTypeHint.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="208118642">
-<g id="58973454">
-<g id="1789283201">
+<g id="726832930">
+<g id="150938929">
+<g id="310941797">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -30,7 +30,7 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1356665701">
+<g id="1118908573">
 <rect x="140" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="178" y="80" text-anchor="middle" class="terminal-text">'string'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_StringVariableDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_StringVariableDeclaration.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1520461674">
-<g id="1654131048">
-<g id="1430898511">
+<g id="925545092">
+<g id="203855430">
+<g id="1512005081">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -24,7 +24,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="542537949">
+<g id="1082308818">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -37,20 +37,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1859504241">
+<g id="2039164605">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="2111227366">
+<g id="748309878">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="1121328389">
-<g id="1604796541">
+<g id="535379288">
+<g id="347503109">
 <rect x="369" y="62" width="118" height="28" class="nonterminal-box"/>
 <text x="428" y="80" text-anchor="middle" class="nonterminal-text">StringTypeHint</text>
 </g>
@@ -64,8 +64,8 @@
 </g>
 <line x1="503" y1="76" x2="523" y2="76" class="rail"/>
 <polygon points="510,73 516,76 510,79" class="arrow"/>
-<g id="1228070701">
-<g id="41997166">
+<g id="1094192563">
+<g id="1060574942">
 <rect x="539" y="62" width="104" height="28" class="nonterminal-box"/>
 <text x="591" y="80" text-anchor="middle" class="nonterminal-text">StringSetter</text>
 </g>
@@ -79,13 +79,13 @@
 </g>
 <line x1="659" y1="76" x2="679" y2="76" class="rail"/>
 <polygon points="666,73 672,76 666,79" class="arrow"/>
-<g id="754178782">
+<g id="1719218627">
 <rect x="679" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="727" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="776" y1="76" x2="796" y2="76" class="rail"/>
 <polygon points="783,73 789,76 783,79" class="arrow"/>
-<g id="1589630064">
+<g id="816628649">
 <rect x="796" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="816" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_TanFunction.svg
+++ b/docs/railroad/TinyExpressionP4_TanFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TanFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1244149221">
-<g id="758052107">
+<g id="1315185668">
+<g id="633202902">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'tan'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="108501689">
+<g id="1355486808">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1731820665">
+<g id="1085853423">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="284429405">
+<g id="72718080">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_TernaryExpression.svg
+++ b/docs/railroad/TinyExpressionP4_TernaryExpression.svg
@@ -14,44 +14,44 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TernaryExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1909118389">
-<g id="471390001">
+<g id="850928097">
+<g id="728612903">
 <rect x="40" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="81" y1="58" x2="101" y2="58" class="rail"/>
 <polygon points="88,55 94,58 88,61" class="arrow"/>
-<g id="1087548238">
+<g id="1797463000">
 <rect x="101" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="240" y1="58" x2="260" y2="58" class="rail"/>
 <polygon points="247,55 253,58 247,61" class="arrow"/>
-<g id="1555376150">
+<g id="2065641473">
 <rect x="260" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="280" y="62" text-anchor="middle" class="terminal-text">'?'</text>
 </g>
 <line x1="301" y1="58" x2="321" y2="58" class="rail"/>
 <polygon points="308,55 314,58 308,61" class="arrow"/>
-<g id="1592882985">
+<g id="1347472005">
 <rect x="321" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="366" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="411" y1="58" x2="431" y2="58" class="rail"/>
 <polygon points="418,55 424,58 418,61" class="arrow"/>
-<g id="76190361">
+<g id="368661584">
 <rect x="431" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="451" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="472" y1="58" x2="492" y2="58" class="rail"/>
 <polygon points="479,55 485,58 479,61" class="arrow"/>
-<g id="1364705693">
+<g id="1727488236">
 <rect x="492" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="537" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="582" y1="58" x2="602" y2="58" class="rail"/>
 <polygon points="589,55 595,58 589,61" class="arrow"/>
-<g id="618112569">
+<g id="1684720395">
 <rect x="602" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="622" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ToLowerCaseDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_ToLowerCaseDotMethod.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToLowerCaseDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2049268765">
-<g id="1737872594">
+<g id="668333245">
+<g id="1846081022">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="769992720">
+<g id="992666221">
 <rect x="157" y="44" width="118" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="216" y="62" text-anchor="middle" class="terminal-text">'.toLowerCase'</text>
 </g>
 <line x1="275" y1="58" x2="295" y2="58" class="rail"/>
 <polygon points="282,55 288,58 282,61" class="arrow"/>
-<g id="2105858843">
+<g id="1007240841">
 <rect x="295" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="315" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="870268400">
+<g id="240867213">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ToLowerCaseFunction.svg
+++ b/docs/railroad/TinyExpressionP4_ToLowerCaseFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToLowerCaseFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1311991619">
-<g id="534638458">
+<g id="1507023485">
+<g id="1986120330">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'toLowerCase'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="483537215">
+<g id="878188311">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="333965307">
+<g id="412070628">
 <rect x="232" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="298" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="364" y1="58" x2="384" y2="58" class="rail"/>
 <polygon points="371,55 377,58 371,61" class="arrow"/>
-<g id="1046866378">
+<g id="555671886">
 <rect x="384" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="404" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ToNumFunction.svg
+++ b/docs/railroad/TinyExpressionP4_ToNumFunction.svg
@@ -14,38 +14,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToNumFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1723593854">
-<g id="247214567">
+<g id="1009158790">
+<g id="787296543">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'toNum'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="97233923">
+<g id="1313818462">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1315855888">
+<g id="1739678477">
 <rect x="190" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1840678721">
+<g id="587220055">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="383" y1="58" x2="403" y2="58" class="rail"/>
 <polygon points="390,55 396,58 390,61" class="arrow"/>
-<g id="40542233">
+<g id="1688399073">
 <rect x="403" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="476" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="549" y1="58" x2="569" y2="58" class="rail"/>
 <polygon points="556,55 562,58 556,61" class="arrow"/>
-<g id="1520025571">
+<g id="1357066908">
 <rect x="569" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="589" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ToUpperCaseDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_ToUpperCaseDotMethod.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToUpperCaseDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1286624439">
-<g id="495909701">
+<g id="756285027">
+<g id="101300663">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="573650916">
+<g id="464199273">
 <rect x="157" y="44" width="118" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="216" y="62" text-anchor="middle" class="terminal-text">'.toUpperCase'</text>
 </g>
 <line x1="275" y1="58" x2="295" y2="58" class="rail"/>
 <polygon points="282,55 288,58 282,61" class="arrow"/>
-<g id="585964282">
+<g id="89789887">
 <rect x="295" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="315" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="646891504">
+<g id="1713121046">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_ToUpperCaseFunction.svg
+++ b/docs/railroad/TinyExpressionP4_ToUpperCaseFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToUpperCaseFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="800080894">
-<g id="1134531173">
+<g id="1244553411">
+<g id="1971076883">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'toUpperCase'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="1585304598">
+<g id="292921548">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="1044883823">
+<g id="637333737">
 <rect x="232" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="298" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="364" y1="58" x2="384" y2="58" class="rail"/>
 <polygon points="371,55 377,58 371,61" class="arrow"/>
-<g id="277079857">
+<g id="1581140144">
 <rect x="384" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="404" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_TrimDotMethod.svg
+++ b/docs/railroad/TinyExpressionP4_TrimDotMethod.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TrimDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1673775560">
-<g id="2122604257">
+<g id="685020433">
+<g id="1258308512">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="620957225">
+<g id="1036740935">
 <rect x="157" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'.trim'</text>
 </g>
 <line x1="226" y1="58" x2="246" y2="58" class="rail"/>
 <polygon points="233,55 239,58 233,61" class="arrow"/>
-<g id="1870239684">
+<g id="1777907276">
 <rect x="246" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="266" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="287" y1="58" x2="307" y2="58" class="rail"/>
 <polygon points="294,55 300,58 294,61" class="arrow"/>
-<g id="1072495490">
+<g id="1627441106">
 <rect x="307" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="327" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_TrimFunction.svg
+++ b/docs/railroad/TinyExpressionP4_TrimFunction.svg
@@ -14,26 +14,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TrimFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1193120474">
-<g id="1139145843">
+<g id="1209983319">
+<g id="759635711">
 <rect x="40" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="71" y="62" text-anchor="middle" class="terminal-text">'trim'</text>
 </g>
 <line x1="102" y1="58" x2="122" y2="58" class="rail"/>
 <polygon points="109,55 115,58 109,61" class="arrow"/>
-<g id="1871774667">
+<g id="1211797793">
 <rect x="122" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="142" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="163" y1="58" x2="183" y2="58" class="rail"/>
 <polygon points="170,55 176,58 170,61" class="arrow"/>
-<g id="2116787274">
+<g id="511188473">
 <rect x="183" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="737670579">
+<g id="1572580601">
 <rect x="335" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_TypeHint.svg
+++ b/docs/railroad/TinyExpressionP4_TypeHint.svg
@@ -14,9 +14,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="115707356">
-<g id="1937800291">
-<g id="1660588740">
+<g id="715246453">
+<g id="1999218488">
+<g id="1836524345">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -30,8 +30,8 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1722897823">
-<g id="2012825561">
+<g id="721339541">
+<g id="2040448598">
 <rect x="159" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="80" text-anchor="middle" class="terminal-text">'number'</text>
 </g>
@@ -39,7 +39,7 @@
 <line x1="235" y1="76" x2="239" y2="76" class="rail"/>
 <line x1="140" y1="76" x2="156" y2="76" class="rail"/>
 <line x1="239" y1="76" x2="255" y2="76" class="rail"/>
-<g id="495114522">
+<g id="1271783956">
 <rect x="159" y="100" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="118" text-anchor="middle" class="terminal-text">'string'</text>
 </g>
@@ -49,7 +49,7 @@
 <path d="M148,106 Q148,114 156,114" class="rail" fill="none"/>
 <path d="M239,114 Q247,114 247,106" class="rail" fill="none"/>
 <path d="M247,84 Q247,76 255,76" class="rail" fill="none"/>
-<g id="727188700">
+<g id="536313535">
 <rect x="156" y="138" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="156" text-anchor="middle" class="terminal-text">'boolean'</text>
 </g>
@@ -59,7 +59,7 @@
 <path d="M148,144 Q148,152 156,152" class="rail" fill="none"/>
 <path d="M239,152 Q247,152 247,144" class="rail" fill="none"/>
 <path d="M247,84 Q247,76 255,76" class="rail" fill="none"/>
-<g id="1540036272">
+<g id="626858526">
 <rect x="159" y="176" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="194" text-anchor="middle" class="terminal-text">'object'</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_VariableDeclaration.svg
+++ b/docs/railroad/TinyExpressionP4_VariableDeclaration.svg
@@ -14,8 +14,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">VariableDeclaration</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="702774992">
-<g id="705991278">
+<g id="1057790745">
+<g id="1166012311">
 <rect x="59" y="44" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="nonterminal-text">NumberVariableDeclaration</text>
 </g>
@@ -23,7 +23,7 @@
 <line x1="254" y1="58" x2="258" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="258" y1="58" x2="274" y2="58" class="rail"/>
-<g id="1113210108">
+<g id="872554990">
 <rect x="59" y="82" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="100" text-anchor="middle" class="nonterminal-text">StringVariableDeclaration</text>
 </g>
@@ -33,7 +33,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M258,96 Q266,96 266,88" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="62893084">
+<g id="133491767">
 <rect x="56" y="120" width="202" height="28" class="nonterminal-box"/>
 <text x="157" y="138" text-anchor="middle" class="nonterminal-text">BooleanVariableDeclaration</text>
 </g>
@@ -43,7 +43,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M258,134 Q266,134 266,126" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="1633245646">
+<g id="162534440">
 <rect x="59" y="158" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="176" text-anchor="middle" class="nonterminal-text">ObjectVariableDeclaration</text>
 </g>

--- a/docs/railroad/TinyExpressionP4_VariableRef.svg
+++ b/docs/railroad/TinyExpressionP4_VariableRef.svg
@@ -14,21 +14,21 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">VariableRef</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="403712491">
-<g id="1504610377">
+<g id="1488221379">
+<g id="584497592">
 <rect x="40" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="81" y1="76" x2="101" y2="76" class="rail"/>
 <polygon points="88,73 94,76 88,79" class="arrow"/>
-<g id="470609380">
+<g id="1356695856">
 <rect x="101" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="146" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="191" y1="76" x2="211" y2="76" class="rail"/>
 <polygon points="198,73 204,76 198,79" class="arrow"/>
-<g id="902890456">
-<g id="995358036">
+<g id="1337466869">
+<g id="494061753">
 <rect x="227" y="62" width="76" height="28" class="nonterminal-box"/>
 <text x="265" y="80" text-anchor="middle" class="nonterminal-text">TypeHint</text>
 </g>

--- a/docs/railroad/index.html
+++ b/docs/railroad/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Railroad Diagrams — /home/opa/work/tinyexpression/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf</title>
+  <title>Railroad Diagrams — /tmp/work/tinyexpression/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf</title>
   <style>
     html { scroll-behavior: smooth; }
     body { font-family: sans-serif; margin: 0; background: #fafafa; color: #222; }
@@ -27,7 +27,7 @@
 <div class="layout">
 <nav class="toc">
   <h1>Railroad Diagrams</h1>
-  <p style="font-size:12px;color:#888;">/home/opa/work/tinyexpression/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf</p>
+  <p style="font-size:12px;color:#888;">/tmp/work/tinyexpression/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf</p>
   <h2>TinyExpressionP4</h2>
   <a href="#Formula">Formula</a>
   <a href="#CodeBlock">CodeBlock</a>
@@ -170,9 +170,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Formula</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1952136147">
-<g id="1477801890">
-<g id="1030517929">
+<g id="1255007795">
+<g id="84781591">
+<g id="746523747">
 <rect x="56" y="68" width="83" height="28" class="nonterminal-box"/>
 <text x="97" y="86" text-anchor="middle" class="nonterminal-text">CodeBlock</text>
 </g>
@@ -192,8 +192,8 @@
 </g>
 <line x1="155" y1="58" x2="175" y2="58" class="rail"/>
 <polygon points="162,55 168,58 162,61" class="arrow"/>
-<g id="1697556844">
-<g id="581953305">
+<g id="1274123413">
+<g id="1596775121">
 <rect x="191" y="68" width="139" height="28" class="nonterminal-box"/>
 <text x="260" y="86" text-anchor="middle" class="nonterminal-text">ImportDeclaration</text>
 </g>
@@ -213,8 +213,8 @@
 </g>
 <line x1="346" y1="58" x2="366" y2="58" class="rail"/>
 <polygon points="353,55 359,58 353,61" class="arrow"/>
-<g id="74631988">
-<g id="1999182356">
+<g id="1598012335">
+<g id="931848795">
 <rect x="382" y="68" width="153" height="28" class="nonterminal-box"/>
 <text x="458" y="86" text-anchor="middle" class="nonterminal-text">VariableDeclaration</text>
 </g>
@@ -234,8 +234,8 @@
 </g>
 <line x1="551" y1="58" x2="571" y2="58" class="rail"/>
 <polygon points="558,55 564,58 558,61" class="arrow"/>
-<g id="1238225950">
-<g id="1505260428">
+<g id="569273773">
+<g id="1719408843">
 <rect x="587" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="632" y="86" text-anchor="middle" class="nonterminal-text">Annotation</text>
 </g>
@@ -255,14 +255,14 @@
 </g>
 <line x1="693" y1="58" x2="713" y2="58" class="rail"/>
 <polygon points="700,55 706,58 700,61" class="arrow"/>
-<g id="1988861577">
+<g id="1100401649">
 <rect x="713" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="758" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="803" y1="58" x2="823" y2="58" class="rail"/>
 <polygon points="810,55 816,58 810,61" class="arrow"/>
-<g id="2123168542">
-<g id="1681047559">
+<g id="1701446750">
+<g id="1675031215">
 <rect x="839" y="68" width="139" height="28" class="nonterminal-box"/>
 <text x="908" y="86" text-anchor="middle" class="nonterminal-text">MethodDeclaration</text>
 </g>
@@ -282,7 +282,7 @@
 </g>
 <line x1="994" y1="58" x2="1014" y2="58" class="rail"/>
 <polygon points="1001,55 1007,58 1001,61" class="arrow"/>
-<g id="1506192885">
+<g id="935038555">
 <rect x="1014" y="44" width="41" height="28" class="nonterminal-box"/>
 <text x="1034" y="62" text-anchor="middle" class="nonterminal-text">EOF</text>
 </g>
@@ -311,20 +311,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CodeBlock</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1102118476">
-<g id="526337349">
+<g id="1606285184">
+<g id="581961862">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">CODE_START</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="4976130">
+<g id="540646640">
 <rect x="150" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="nonterminal-text">CODE_BODY</text>
 </g>
 <line x1="233" y1="58" x2="253" y2="58" class="rail"/>
 <polygon points="240,55 246,58 240,61" class="arrow"/>
-<g id="1813562815">
+<g id="2053401217">
 <rect x="253" y="44" width="76" height="28" class="nonterminal-box"/>
 <text x="291" y="62" text-anchor="middle" class="nonterminal-text">CODE_END</text>
 </g>
@@ -353,28 +353,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ImportDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="39343965">
-<g id="392162873">
+<g id="1604952262">
+<g id="2013352497">
 <rect x="40" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="80" text-anchor="middle" class="terminal-text">'import'</text>
 </g>
 <line x1="116" y1="76" x2="136" y2="76" class="rail"/>
 <polygon points="123,73 129,76 123,79" class="arrow"/>
-<g id="883839214">
+<g id="1556666512">
 <rect x="136" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="177" y="80" text-anchor="middle" class="nonterminal-text">ClassName</text>
 </g>
 <line x1="219" y1="76" x2="239" y2="76" class="rail"/>
 <polygon points="226,73 232,76 226,79" class="arrow"/>
-<g id="839381269">
-<g id="244988123">
-<g id="1850311742">
+<g id="1597809012">
+<g id="1029107464">
+<g id="35867580">
 <rect x="255" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="275" y="80" text-anchor="middle" class="terminal-text">'#'</text>
 </g>
 <line x1="296" y1="76" x2="316" y2="76" class="rail"/>
 <polygon points="303,73 309,76 303,79" class="arrow"/>
-<g id="1717316623">
+<g id="1337244693">
 <rect x="316" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="361" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
@@ -389,19 +389,19 @@
 </g>
 <line x1="422" y1="76" x2="442" y2="76" class="rail"/>
 <polygon points="429,73 435,76 429,79" class="arrow"/>
-<g id="1402311827">
+<g id="2109564165">
 <rect x="442" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="466" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="490" y1="76" x2="510" y2="76" class="rail"/>
 <polygon points="497,73 503,76 497,79" class="arrow"/>
-<g id="1083553990">
+<g id="1903945186">
 <rect x="510" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="555" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="600" y1="76" x2="620" y2="76" class="rail"/>
 <polygon points="607,73 613,76 607,79" class="arrow"/>
-<g id="257593594">
+<g id="1705282055">
 <rect x="620" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="640" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>
@@ -430,22 +430,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ClassName</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="277762388">
-<g id="2107009673">
+<g id="1326983763">
+<g id="1235903355">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="1166050455">
-<g id="185361757">
-<g id="279490165">
+<g id="779331271">
+<g id="886614684">
+<g id="1741736793">
 <rect x="166" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="86" text-anchor="middle" class="terminal-text">'.'</text>
 </g>
 <line x1="207" y1="82" x2="227" y2="82" class="rail"/>
 <polygon points="214,79 220,82 214,85" class="arrow"/>
-<g id="1261314522">
+<g id="652574998">
 <rect x="227" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="272" y="86" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
@@ -489,8 +489,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">VariableDeclaration</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="702774992">
-<g id="705991278">
+<g id="1057790745">
+<g id="1166012311">
 <rect x="59" y="44" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="nonterminal-text">NumberVariableDeclaration</text>
 </g>
@@ -498,7 +498,7 @@
 <line x1="254" y1="58" x2="258" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="258" y1="58" x2="274" y2="58" class="rail"/>
-<g id="1113210108">
+<g id="872554990">
 <rect x="59" y="82" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="100" text-anchor="middle" class="nonterminal-text">StringVariableDeclaration</text>
 </g>
@@ -508,7 +508,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M258,96 Q266,96 266,88" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="62893084">
+<g id="133491767">
 <rect x="56" y="120" width="202" height="28" class="nonterminal-box"/>
 <text x="157" y="138" text-anchor="middle" class="nonterminal-text">BooleanVariableDeclaration</text>
 </g>
@@ -518,7 +518,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M258,134 Q266,134 266,126" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="1633245646">
+<g id="162534440">
 <rect x="59" y="158" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="176" text-anchor="middle" class="nonterminal-text">ObjectVariableDeclaration</text>
 </g>
@@ -553,9 +553,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1255914800">
-<g id="1305787071">
-<g id="849407531">
+<g id="1133692791">
+<g id="1503676706">
+<g id="1152041657">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -563,7 +563,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="600146705">
+<g id="852172222">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -576,20 +576,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1340953555">
+<g id="676405795">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="1782332500">
+<g id="1235749761">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="1216139296">
-<g id="1452100458">
+<g id="129654765">
+<g id="608978003">
 <rect x="369" y="62" width="118" height="28" class="nonterminal-box"/>
 <text x="428" y="80" text-anchor="middle" class="nonterminal-text">NumberTypeHint</text>
 </g>
@@ -603,8 +603,8 @@
 </g>
 <line x1="503" y1="76" x2="523" y2="76" class="rail"/>
 <polygon points="510,73 516,76 510,79" class="arrow"/>
-<g id="1728003658">
-<g id="1839882551">
+<g id="791070282">
+<g id="643511555">
 <rect x="539" y="62" width="104" height="28" class="nonterminal-box"/>
 <text x="591" y="80" text-anchor="middle" class="nonterminal-text">NumberSetter</text>
 </g>
@@ -618,13 +618,13 @@
 </g>
 <line x1="659" y1="76" x2="679" y2="76" class="rail"/>
 <polygon points="666,73 672,76 666,79" class="arrow"/>
-<g id="1519779812">
+<g id="1770938657">
 <rect x="679" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="727" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="776" y1="76" x2="796" y2="76" class="rail"/>
 <polygon points="783,73 789,76 783,79" class="arrow"/>
-<g id="1959184710">
+<g id="1016995530">
 <rect x="796" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="816" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>
@@ -653,9 +653,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1520461674">
-<g id="1654131048">
-<g id="1430898511">
+<g id="925545092">
+<g id="203855430">
+<g id="1512005081">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -663,7 +663,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="542537949">
+<g id="1082308818">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -676,20 +676,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1859504241">
+<g id="2039164605">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="2111227366">
+<g id="748309878">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="1121328389">
-<g id="1604796541">
+<g id="535379288">
+<g id="347503109">
 <rect x="369" y="62" width="118" height="28" class="nonterminal-box"/>
 <text x="428" y="80" text-anchor="middle" class="nonterminal-text">StringTypeHint</text>
 </g>
@@ -703,8 +703,8 @@
 </g>
 <line x1="503" y1="76" x2="523" y2="76" class="rail"/>
 <polygon points="510,73 516,76 510,79" class="arrow"/>
-<g id="1228070701">
-<g id="41997166">
+<g id="1094192563">
+<g id="1060574942">
 <rect x="539" y="62" width="104" height="28" class="nonterminal-box"/>
 <text x="591" y="80" text-anchor="middle" class="nonterminal-text">StringSetter</text>
 </g>
@@ -718,13 +718,13 @@
 </g>
 <line x1="659" y1="76" x2="679" y2="76" class="rail"/>
 <polygon points="666,73 672,76 666,79" class="arrow"/>
-<g id="754178782">
+<g id="1719218627">
 <rect x="679" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="727" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="776" y1="76" x2="796" y2="76" class="rail"/>
 <polygon points="783,73 789,76 783,79" class="arrow"/>
-<g id="1589630064">
+<g id="816628649">
 <rect x="796" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="816" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>
@@ -753,9 +753,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="587668039">
-<g id="396312870">
-<g id="95686820">
+<g id="1852377273">
+<g id="1338086756">
+<g id="922641479">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -763,7 +763,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="925044710">
+<g id="430357618">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -776,20 +776,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1800005591">
+<g id="1753490722">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="1144691047">
+<g id="1148010860">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="138505656">
-<g id="700540599">
+<g id="1193111474">
+<g id="121931312">
 <rect x="369" y="62" width="125" height="28" class="nonterminal-box"/>
 <text x="431" y="80" text-anchor="middle" class="nonterminal-text">BooleanTypeHint</text>
 </g>
@@ -803,8 +803,8 @@
 </g>
 <line x1="510" y1="76" x2="530" y2="76" class="rail"/>
 <polygon points="517,73 523,76 517,79" class="arrow"/>
-<g id="1014169964">
-<g id="747787320">
+<g id="540129748">
+<g id="251260742">
 <rect x="546" y="62" width="111" height="28" class="nonterminal-box"/>
 <text x="601" y="80" text-anchor="middle" class="nonterminal-text">BooleanSetter</text>
 </g>
@@ -818,13 +818,13 @@
 </g>
 <line x1="673" y1="76" x2="693" y2="76" class="rail"/>
 <polygon points="680,73 686,76 680,79" class="arrow"/>
-<g id="505752715">
+<g id="65523428">
 <rect x="693" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="741" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="790" y1="76" x2="810" y2="76" class="rail"/>
 <polygon points="797,73 803,76 797,79" class="arrow"/>
-<g id="495631962">
+<g id="799752661">
 <rect x="810" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="830" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>
@@ -853,9 +853,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectVariableDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="157051325">
-<g id="2015175199">
-<g id="131798826">
+<g id="846201387">
+<g id="189191722">
+<g id="1128002489">
 <rect x="73" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="100" y="80" text-anchor="middle" class="terminal-text">'var'</text>
 </g>
@@ -863,7 +863,7 @@
 <line x1="128" y1="76" x2="146" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="146" y1="76" x2="162" y2="76" class="rail"/>
-<g id="808264238">
+<g id="2115405268">
 <rect x="56" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="101" y="118" text-anchor="middle" class="terminal-text">'variable'</text>
 </g>
@@ -876,20 +876,20 @@
 </g>
 <line x1="162" y1="76" x2="182" y2="76" class="rail"/>
 <polygon points="169,73 175,76 169,79" class="arrow"/>
-<g id="1022288766">
+<g id="838251264">
 <rect x="182" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="202" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="223" y1="76" x2="243" y2="76" class="rail"/>
 <polygon points="230,73 236,76 230,79" class="arrow"/>
-<g id="1695259295">
+<g id="2072291535">
 <rect x="243" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="288" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="333" y1="76" x2="353" y2="76" class="rail"/>
 <polygon points="340,73 346,76 340,79" class="arrow"/>
-<g id="166350082">
-<g id="1947681275">
+<g id="177678338">
+<g id="1179571731">
 <rect x="369" y="62" width="118" height="28" class="nonterminal-box"/>
 <text x="428" y="80" text-anchor="middle" class="nonterminal-text">ObjectTypeHint</text>
 </g>
@@ -903,8 +903,8 @@
 </g>
 <line x1="503" y1="76" x2="523" y2="76" class="rail"/>
 <polygon points="510,73 516,76 510,79" class="arrow"/>
-<g id="2066878453">
-<g id="1121237586">
+<g id="1356986163">
+<g id="243131619">
 <rect x="539" y="62" width="104" height="28" class="nonterminal-box"/>
 <text x="591" y="80" text-anchor="middle" class="nonterminal-text">ObjectSetter</text>
 </g>
@@ -918,13 +918,13 @@
 </g>
 <line x1="659" y1="76" x2="679" y2="76" class="rail"/>
 <polygon points="666,73 672,76 666,79" class="arrow"/>
-<g id="904167921">
+<g id="1613712754">
 <rect x="679" y="62" width="97" height="28" class="nonterminal-box"/>
 <text x="727" y="80" text-anchor="middle" class="nonterminal-text">Description</text>
 </g>
 <line x1="776" y1="76" x2="796" y2="76" class="rail"/>
 <polygon points="783,73 789,76 783,79" class="arrow"/>
-<g id="1857898514">
+<g id="1405857357">
 <rect x="796" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="816" y="80" text-anchor="middle" class="terminal-text">';'</text>
 </g>
@@ -953,9 +953,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="115707356">
-<g id="1937800291">
-<g id="1660588740">
+<g id="715246453">
+<g id="1999218488">
+<g id="1836524345">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -969,8 +969,8 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1722897823">
-<g id="2012825561">
+<g id="721339541">
+<g id="2040448598">
 <rect x="159" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="80" text-anchor="middle" class="terminal-text">'number'</text>
 </g>
@@ -978,7 +978,7 @@
 <line x1="235" y1="76" x2="239" y2="76" class="rail"/>
 <line x1="140" y1="76" x2="156" y2="76" class="rail"/>
 <line x1="239" y1="76" x2="255" y2="76" class="rail"/>
-<g id="495114522">
+<g id="1271783956">
 <rect x="159" y="100" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="118" text-anchor="middle" class="terminal-text">'string'</text>
 </g>
@@ -988,7 +988,7 @@
 <path d="M148,106 Q148,114 156,114" class="rail" fill="none"/>
 <path d="M239,114 Q247,114 247,106" class="rail" fill="none"/>
 <path d="M247,84 Q247,76 255,76" class="rail" fill="none"/>
-<g id="727188700">
+<g id="536313535">
 <rect x="156" y="138" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="156" text-anchor="middle" class="terminal-text">'boolean'</text>
 </g>
@@ -998,7 +998,7 @@
 <path d="M148,144 Q148,152 156,152" class="rail" fill="none"/>
 <path d="M239,152 Q247,152 247,144" class="rail" fill="none"/>
 <path d="M247,84 Q247,76 255,76" class="rail" fill="none"/>
-<g id="1540036272">
+<g id="626858526">
 <rect x="159" y="176" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="197" y="194" text-anchor="middle" class="terminal-text">'object'</text>
 </g>
@@ -1034,9 +1034,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="2122599488">
-<g id="1776932263">
-<g id="93877542">
+<g id="1269056972">
+<g id="1004995536">
+<g id="1742846421">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -1050,8 +1050,8 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1752184716">
-<g id="69644314">
+<g id="1094413015">
+<g id="253811086">
 <rect x="156" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="194" y="80" text-anchor="middle" class="terminal-text">'number'</text>
 </g>
@@ -1059,7 +1059,7 @@
 <line x1="232" y1="76" x2="232" y2="76" class="rail"/>
 <line x1="140" y1="76" x2="156" y2="76" class="rail"/>
 <line x1="232" y1="76" x2="248" y2="76" class="rail"/>
-<g id="772228655">
+<g id="729694588">
 <rect x="159" y="100" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="193" y="118" text-anchor="middle" class="terminal-text">'float'</text>
 </g>
@@ -1095,9 +1095,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="208118642">
-<g id="58973454">
-<g id="1789283201">
+<g id="726832930">
+<g id="150938929">
+<g id="310941797">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -1111,7 +1111,7 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1356665701">
+<g id="1118908573">
 <rect x="140" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="178" y="80" text-anchor="middle" class="terminal-text">'string'</text>
 </g>
@@ -1140,9 +1140,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1082188311">
-<g id="1228134151">
-<g id="1422199612">
+<g id="2026014007">
+<g id="208149928">
+<g id="2102356381">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -1156,7 +1156,7 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="1900913535">
+<g id="1201070432">
 <rect x="140" y="62" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="181" y="80" text-anchor="middle" class="terminal-text">'boolean'</text>
 </g>
@@ -1185,9 +1185,9 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectTypeHint</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="815868484">
-<g id="1807543972">
-<g id="1021349328">
+<g id="786721688">
+<g id="848224030">
+<g id="2126977075">
 <rect x="56" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
@@ -1201,7 +1201,7 @@
 </g>
 <line x1="120" y1="76" x2="140" y2="76" class="rail"/>
 <polygon points="127,73 133,76 127,79" class="arrow"/>
-<g id="2012675831">
+<g id="1122215374">
 <rect x="140" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="178" y="80" text-anchor="middle" class="terminal-text">'object'</text>
 </g>
@@ -1230,28 +1230,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="933361453">
-<g id="135769997">
+<g id="227445305">
+<g id="1747249399">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="1502329223">
-<g id="1216855283">
-<g id="80914917">
+<g id="678713892">
+<g id="824017017">
+<g id="739683522">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="1150545614">
+<g id="1929683291">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="2102992658">
+<g id="2125577224">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -1266,7 +1266,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="45468134">
+<g id="2116827144">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -1295,28 +1295,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1960953964">
-<g id="1110750478">
+<g id="84095450">
+<g id="1355668921">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="1210747160">
-<g id="897231330">
-<g id="1182231374">
+<g id="1221000562">
+<g id="44642337">
+<g id="1516374270">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="1788965023">
+<g id="1158780866">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="1384245881">
+<g id="1018630683">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -1331,7 +1331,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="703479050">
+<g id="18926639">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -1360,28 +1360,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="2104839723">
-<g id="347364011">
+<g id="1346708350">
+<g id="1323315555">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="1192312520">
-<g id="471564068">
-<g id="139092844">
+<g id="1192506766">
+<g id="1707189998">
+<g id="825391264">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="1343490306">
+<g id="922000157">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="709626308">
+<g id="719712760">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -1396,7 +1396,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="935158577">
+<g id="1437233666">
 <rect x="386" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="455" y="80" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
@@ -1425,28 +1425,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectSetter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="850068028">
-<g id="986770686">
+<g id="1976569577">
+<g id="945494350">
 <rect x="40" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="80" text-anchor="middle" class="terminal-text">'set'</text>
 </g>
 <line x1="95" y1="76" x2="115" y2="76" class="rail"/>
 <polygon points="102,73 108,76 102,79" class="arrow"/>
-<g id="2106463177">
-<g id="1121484914">
-<g id="1954112018">
+<g id="814209200">
+<g id="1097849472">
+<g id="1585832846">
 <rect x="131" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="155" y="80" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="671167303">
+<g id="1488564286">
 <rect x="199" y="62" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="226" y="80" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="254" y1="76" x2="274" y2="76" class="rail"/>
 <polygon points="261,73 267,76 261,79" class="arrow"/>
-<g id="2136089722">
+<g id="555628164">
 <rect x="274" y="62" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="312" y="80" text-anchor="middle" class="terminal-text">'exists'</text>
 </g>
@@ -1461,7 +1461,7 @@
 </g>
 <line x1="366" y1="76" x2="386" y2="76" class="rail"/>
 <polygon points="373,73 379,76 373,79" class="arrow"/>
-<g id="1546947636">
+<g id="623552222">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">ObjectExpression</text>
 </g>
@@ -1490,20 +1490,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Description</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="722906324">
-<g id="888594187">
+<g id="1093060497">
+<g id="1247047945">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'description'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="971739655">
+<g id="1142452907">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'='</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="1095167010">
+<g id="888414368">
 <rect x="232" y="44" width="62" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">STRING</text>
 </g>
@@ -1532,27 +1532,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Annotation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="618876592">
-<g id="697966650">
+<g id="1326634265">
+<g id="680733317">
 <rect x="40" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="80" text-anchor="middle" class="terminal-text">'@'</text>
 </g>
 <line x1="81" y1="76" x2="101" y2="76" class="rail"/>
 <polygon points="88,73 94,76 88,79" class="arrow"/>
-<g id="1283777700">
+<g id="790202390">
 <rect x="101" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="146" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="191" y1="76" x2="211" y2="76" class="rail"/>
 <polygon points="198,73 204,76 198,79" class="arrow"/>
-<g id="978659050">
+<g id="981294197">
 <rect x="211" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="231" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="252" y1="76" x2="272" y2="76" class="rail"/>
 <polygon points="259,73 265,76 259,79" class="arrow"/>
-<g id="1549279781">
-<g id="616258936">
+<g id="2087109313">
+<g id="1292902116">
 <rect x="288" y="62" width="160" height="28" class="nonterminal-box"/>
 <text x="368" y="80" text-anchor="middle" class="nonterminal-text">AnnotationParameters</text>
 </g>
@@ -1566,7 +1566,7 @@
 </g>
 <line x1="464" y1="76" x2="484" y2="76" class="rail"/>
 <polygon points="471,73 477,76 471,79" class="arrow"/>
-<g id="923950286">
+<g id="534555747">
 <rect x="484" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="504" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -1595,22 +1595,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AnnotationParameters</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1674064591">
-<g id="1523423177">
+<g id="1951610538">
+<g id="45618465">
 <rect x="40" y="44" width="153" height="28" class="nonterminal-box"/>
 <text x="116" y="62" text-anchor="middle" class="nonterminal-text">AnnotationParameter</text>
 </g>
 <line x1="193" y1="58" x2="213" y2="58" class="rail"/>
 <polygon points="200,55 206,58 200,61" class="arrow"/>
-<g id="1780870147">
-<g id="1558207369">
-<g id="1201262527">
+<g id="704056766">
+<g id="1805917430">
+<g id="1216528253">
 <rect x="229" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="249" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="270" y1="82" x2="290" y2="82" class="rail"/>
 <polygon points="277,79 283,82 277,85" class="arrow"/>
-<g id="1657278382">
+<g id="843558330">
 <rect x="290" y="68" width="153" height="28" class="nonterminal-box"/>
 <text x="366" y="86" text-anchor="middle" class="nonterminal-text">AnnotationParameter</text>
 </g>
@@ -1654,20 +1654,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AnnotationParameter</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2025946628">
-<g id="1096807527">
+<g id="1291745917">
+<g id="2079748071">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="532534230">
+<g id="813604803">
 <rect x="150" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="terminal-text">'='</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="1522364886">
+<g id="569769615">
 <rect x="211" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
@@ -1696,8 +1696,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodDeclaration</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="692288323">
-<g id="1183011255">
+<g id="139093477">
+<g id="71286098">
 <rect x="59" y="44" width="181" height="28" class="nonterminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="nonterminal-text">NumberMethodDeclaration</text>
 </g>
@@ -1705,7 +1705,7 @@
 <line x1="240" y1="58" x2="244" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="244" y1="58" x2="260" y2="58" class="rail"/>
-<g id="936450514">
+<g id="1081846417">
 <rect x="59" y="82" width="181" height="28" class="nonterminal-box"/>
 <text x="149" y="100" text-anchor="middle" class="nonterminal-text">StringMethodDeclaration</text>
 </g>
@@ -1715,7 +1715,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M244,96 Q252,96 252,88" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="114552127">
+<g id="1324623255">
 <rect x="56" y="120" width="188" height="28" class="nonterminal-box"/>
 <text x="150" y="138" text-anchor="middle" class="nonterminal-text">BooleanMethodDeclaration</text>
 </g>
@@ -1725,7 +1725,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M244,134 Q252,134 252,126" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1964081855">
+<g id="1910932390">
 <rect x="59" y="158" width="181" height="28" class="nonterminal-box"/>
 <text x="149" y="176" text-anchor="middle" class="nonterminal-text">ObjectMethodDeclaration</text>
 </g>
@@ -1760,27 +1760,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="953784350">
-<g id="384038960">
+<g id="1184766982">
+<g id="368605535">
 <rect x="40" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="80" text-anchor="middle" class="nonterminal-text">NumberReturnType</text>
 </g>
 <line x1="172" y1="76" x2="192" y2="76" class="rail"/>
 <polygon points="179,73 185,76 179,79" class="arrow"/>
-<g id="264263110">
+<g id="2052013802">
 <rect x="192" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="282" y1="76" x2="302" y2="76" class="rail"/>
 <polygon points="289,73 295,76 289,79" class="arrow"/>
-<g id="1992112891">
+<g id="1064401334">
 <rect x="302" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="322" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="343" y1="76" x2="363" y2="76" class="rail"/>
 <polygon points="350,73 356,76 350,79" class="arrow"/>
-<g id="1304267990">
-<g id="1150737932">
+<g id="841742775">
+<g id="1691305712">
 <rect x="379" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="445" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -1794,25 +1794,25 @@
 </g>
 <line x1="527" y1="76" x2="547" y2="76" class="rail"/>
 <polygon points="534,73 540,76 534,79" class="arrow"/>
-<g id="1079938754">
+<g id="831535478">
 <rect x="547" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="567" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="588" y1="76" x2="608" y2="76" class="rail"/>
 <polygon points="595,73 601,76 595,79" class="arrow"/>
-<g id="1596661456">
+<g id="85482043">
 <rect x="608" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="628" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="649" y1="76" x2="669" y2="76" class="rail"/>
 <polygon points="656,73 662,76 656,79" class="arrow"/>
-<g id="767548807">
+<g id="469660846">
 <rect x="669" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="735" y="80" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="801" y1="76" x2="821" y2="76" class="rail"/>
 <polygon points="808,73 814,76 808,79" class="arrow"/>
-<g id="214253530">
+<g id="1995816999">
 <rect x="821" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="841" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -1841,27 +1841,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1367004142">
-<g id="1065602123">
+<g id="1489509398">
+<g id="17850220">
 <rect x="40" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="80" text-anchor="middle" class="nonterminal-text">StringReturnType</text>
 </g>
 <line x1="172" y1="76" x2="192" y2="76" class="rail"/>
 <polygon points="179,73 185,76 179,79" class="arrow"/>
-<g id="1812168153">
+<g id="1763901668">
 <rect x="192" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="282" y1="76" x2="302" y2="76" class="rail"/>
 <polygon points="289,73 295,76 289,79" class="arrow"/>
-<g id="1235072108">
+<g id="823066911">
 <rect x="302" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="322" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="343" y1="76" x2="363" y2="76" class="rail"/>
 <polygon points="350,73 356,76 350,79" class="arrow"/>
-<g id="472956488">
-<g id="1039191081">
+<g id="78614975">
+<g id="130499860">
 <rect x="379" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="445" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -1875,25 +1875,25 @@
 </g>
 <line x1="527" y1="76" x2="547" y2="76" class="rail"/>
 <polygon points="534,73 540,76 534,79" class="arrow"/>
-<g id="1797973410">
+<g id="1979352558">
 <rect x="547" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="567" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="588" y1="76" x2="608" y2="76" class="rail"/>
 <polygon points="595,73 601,76 595,79" class="arrow"/>
-<g id="1336939135">
+<g id="1010066871">
 <rect x="608" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="628" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="649" y1="76" x2="669" y2="76" class="rail"/>
 <polygon points="656,73 662,76 656,79" class="arrow"/>
-<g id="1956253220">
+<g id="31877312">
 <rect x="669" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="735" y="80" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="801" y1="76" x2="821" y2="76" class="rail"/>
 <polygon points="808,73 814,76 808,79" class="arrow"/>
-<g id="1841376257">
+<g id="2033984298">
 <rect x="821" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="841" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -1922,27 +1922,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="743124741">
-<g id="513146964">
+<g id="1597480639">
+<g id="1196344165">
 <rect x="40" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="80" text-anchor="middle" class="nonterminal-text">BooleanReturnType</text>
 </g>
 <line x1="179" y1="76" x2="199" y2="76" class="rail"/>
 <polygon points="186,73 192,76 186,79" class="arrow"/>
-<g id="978962060">
+<g id="1977352996">
 <rect x="199" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="244" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="289" y1="76" x2="309" y2="76" class="rail"/>
 <polygon points="296,73 302,76 296,79" class="arrow"/>
-<g id="1587299554">
+<g id="1843485638">
 <rect x="309" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="329" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="350" y1="76" x2="370" y2="76" class="rail"/>
 <polygon points="357,73 363,76 357,79" class="arrow"/>
-<g id="2000959143">
-<g id="1501432188">
+<g id="1144353508">
+<g id="1968296640">
 <rect x="386" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="452" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -1956,25 +1956,25 @@
 </g>
 <line x1="534" y1="76" x2="554" y2="76" class="rail"/>
 <polygon points="541,73 547,76 541,79" class="arrow"/>
-<g id="64873317">
+<g id="1365609573">
 <rect x="554" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="574" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="595" y1="76" x2="615" y2="76" class="rail"/>
 <polygon points="602,73 608,76 602,79" class="arrow"/>
-<g id="1071254696">
+<g id="910021348">
 <rect x="615" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="635" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="656" y1="76" x2="676" y2="76" class="rail"/>
 <polygon points="663,73 669,76 663,79" class="arrow"/>
-<g id="373737414">
+<g id="1300349233">
 <rect x="676" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="745" y="80" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="815" y1="76" x2="835" y2="76" class="rail"/>
 <polygon points="822,73 828,76 822,79" class="arrow"/>
-<g id="1080113831">
+<g id="575420471">
 <rect x="835" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="855" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -2003,27 +2003,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectMethodDeclaration</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1606302880">
-<g id="1134287208">
+<g id="1198903654">
+<g id="122015055">
 <rect x="40" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="80" text-anchor="middle" class="nonterminal-text">ObjectReturnType</text>
 </g>
 <line x1="172" y1="76" x2="192" y2="76" class="rail"/>
 <polygon points="179,73 185,76 179,79" class="arrow"/>
-<g id="1673748010">
+<g id="1150164191">
 <rect x="192" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="282" y1="76" x2="302" y2="76" class="rail"/>
 <polygon points="289,73 295,76 289,79" class="arrow"/>
-<g id="717153527">
+<g id="121637369">
 <rect x="302" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="322" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="343" y1="76" x2="363" y2="76" class="rail"/>
 <polygon points="350,73 356,76 350,79" class="arrow"/>
-<g id="1110775724">
-<g id="1610139042">
+<g id="1306995646">
+<g id="1684127176">
 <rect x="379" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="445" y="80" text-anchor="middle" class="nonterminal-text">MethodParameters</text>
 </g>
@@ -2037,25 +2037,25 @@
 </g>
 <line x1="527" y1="76" x2="547" y2="76" class="rail"/>
 <polygon points="534,73 540,76 534,79" class="arrow"/>
-<g id="998122446">
+<g id="2033958457">
 <rect x="547" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="567" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="588" y1="76" x2="608" y2="76" class="rail"/>
 <polygon points="595,73 601,76 595,79" class="arrow"/>
-<g id="1723523338">
+<g id="2125692710">
 <rect x="608" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="628" y="80" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="649" y1="76" x2="669" y2="76" class="rail"/>
 <polygon points="656,73 662,76 656,79" class="arrow"/>
-<g id="2138500522">
+<g id="391451333">
 <rect x="669" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="735" y="80" text-anchor="middle" class="nonterminal-text">ObjectExpression</text>
 </g>
 <line x1="801" y1="76" x2="821" y2="76" class="rail"/>
 <polygon points="808,73 814,76 808,79" class="arrow"/>
-<g id="353639839">
+<g id="1662738762">
 <rect x="821" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="841" y="80" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -2084,22 +2084,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodParameters</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1745765867">
-<g id="1857893612">
+<g id="349297612">
+<g id="576376033">
 <rect x="40" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="102" y="62" text-anchor="middle" class="nonterminal-text">MethodParameter</text>
 </g>
 <line x1="165" y1="58" x2="185" y2="58" class="rail"/>
 <polygon points="172,55 178,58 172,61" class="arrow"/>
-<g id="978037345">
-<g id="1029108595">
-<g id="644779820">
+<g id="953284874">
+<g id="1285032380">
+<g id="497426773">
 <rect x="201" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="221" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="242" y1="82" x2="262" y2="82" class="rail"/>
 <polygon points="249,79 255,82 249,85" class="arrow"/>
-<g id="329488027">
+<g id="621744794">
 <rect x="262" y="68" width="125" height="28" class="nonterminal-box"/>
 <text x="324" y="86" text-anchor="middle" class="nonterminal-text">MethodParameter</text>
 </g>
@@ -2143,28 +2143,28 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodParameter</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1560507072">
-<g id="1729495359">
+<g id="1606110544">
+<g id="1226280974">
 <rect x="40" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="81" y1="76" x2="101" y2="76" class="rail"/>
 <polygon points="88,73 94,76 88,79" class="arrow"/>
-<g id="1842461637">
+<g id="1162786169">
 <rect x="101" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="146" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="191" y1="76" x2="211" y2="76" class="rail"/>
 <polygon points="198,73 204,76 198,79" class="arrow"/>
-<g id="665997686">
-<g id="1205720539">
-<g id="170794172">
+<g id="767706638">
+<g id="488099240">
+<g id="1927286131">
 <rect x="227" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="251" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="275" y1="76" x2="295" y2="76" class="rail"/>
 <polygon points="282,73 288,76 282,79" class="arrow"/>
-<g id="278208783">
+<g id="1760929624">
 <rect x="295" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="340" y="80" text-anchor="middle" class="nonterminal-text">ReturnType</text>
 </g>
@@ -2202,8 +2202,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2029063772">
-<g id="1688710454">
+<g id="103143918">
+<g id="439479960">
 <rect x="56" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="94" y="62" text-anchor="middle" class="terminal-text">'number'</text>
 </g>
@@ -2211,7 +2211,7 @@
 <line x1="132" y1="58" x2="132" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="132" y1="58" x2="148" y2="58" class="rail"/>
-<g id="1308479348">
+<g id="963123963">
 <rect x="59" y="82" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="93" y="100" text-anchor="middle" class="terminal-text">'float'</text>
 </g>
@@ -2246,7 +2246,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1050867440">
+<g id="57791927">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'string'</text>
 </g>
@@ -2274,7 +2274,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1739923983">
+<g id="379698799">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'boolean'</text>
 </g>
@@ -2302,7 +2302,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1141954530">
+<g id="1869074818">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'object'</text>
 </g>
@@ -2330,8 +2330,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ReturnType</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="948280510">
-<g id="887333586">
+<g id="1806700666">
+<g id="1193643817">
 <rect x="59" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="125" y="62" text-anchor="middle" class="nonterminal-text">NumberReturnType</text>
 </g>
@@ -2339,7 +2339,7 @@
 <line x1="191" y1="58" x2="195" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="195" y1="58" x2="211" y2="58" class="rail"/>
-<g id="501209032">
+<g id="1249130007">
 <rect x="59" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="125" y="100" text-anchor="middle" class="nonterminal-text">StringReturnType</text>
 </g>
@@ -2349,7 +2349,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M195,96 Q203,96 203,88" class="rail" fill="none"/>
 <path d="M203,66 Q203,58 211,58" class="rail" fill="none"/>
-<g id="1395931942">
+<g id="1371388912">
 <rect x="56" y="120" width="139" height="28" class="nonterminal-box"/>
 <text x="125" y="138" text-anchor="middle" class="nonterminal-text">BooleanReturnType</text>
 </g>
@@ -2359,7 +2359,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M195,134 Q203,134 203,126" class="rail" fill="none"/>
 <path d="M203,66 Q203,58 211,58" class="rail" fill="none"/>
-<g id="299452773">
+<g id="8887172">
 <rect x="59" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="125" y="176" text-anchor="middle" class="nonterminal-text">ObjectReturnType</text>
 </g>
@@ -2394,45 +2394,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalBooleanInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="897519922">
-<g id="1535602161">
+<g id="134008146">
+<g id="2049941">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="689471660">
+<g id="1019285085">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="1926329995">
+<g id="2550266">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="1722119171">
+<g id="1803422276">
 <rect x="335" y="62" width="139" height="28" class="nonterminal-box"/>
 <text x="404" y="80" text-anchor="middle" class="nonterminal-text">BooleanReturnType</text>
 </g>
 <line x1="474" y1="76" x2="494" y2="76" class="rail"/>
 <polygon points="481,73 487,76 481,79" class="arrow"/>
-<g id="103642563">
+<g id="287824721">
 <rect x="494" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="539" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="584" y1="76" x2="604" y2="76" class="rail"/>
 <polygon points="591,73 597,76 591,79" class="arrow"/>
-<g id="1809680458">
+<g id="631282894">
 <rect x="604" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="624" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="645" y1="76" x2="665" y2="76" class="rail"/>
 <polygon points="652,73 658,76 652,79" class="arrow"/>
-<g id="1594471859">
-<g id="306306708">
+<g id="155835544">
+<g id="310302905">
 <rect x="681" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="722" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -2446,7 +2446,7 @@
 </g>
 <line x1="780" y1="76" x2="800" y2="76" class="rail"/>
 <polygon points="787,73 793,76 787,79" class="arrow"/>
-<g id="854020348">
+<g id="639333299">
 <rect x="800" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="820" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -2475,45 +2475,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalNumberInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="250313171">
-<g id="701946999">
+<g id="2082652524">
+<g id="1671652868">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="996167891">
+<g id="608816116">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="856197107">
+<g id="1504883237">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="2117334561">
+<g id="952459804">
 <rect x="335" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="80" text-anchor="middle" class="nonterminal-text">NumberReturnType</text>
 </g>
 <line x1="467" y1="76" x2="487" y2="76" class="rail"/>
 <polygon points="474,73 480,76 474,79" class="arrow"/>
-<g id="1637464308">
+<g id="1085190214">
 <rect x="487" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="532" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="577" y1="76" x2="597" y2="76" class="rail"/>
 <polygon points="584,73 590,76 584,79" class="arrow"/>
-<g id="1481022172">
+<g id="710071756">
 <rect x="597" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="638" y1="76" x2="658" y2="76" class="rail"/>
 <polygon points="645,73 651,76 645,79" class="arrow"/>
-<g id="1323679751">
-<g id="788969784">
+<g id="1979396704">
+<g id="1715300665">
 <rect x="674" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="715" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -2527,7 +2527,7 @@
 </g>
 <line x1="773" y1="76" x2="793" y2="76" class="rail"/>
 <polygon points="780,73 786,76 780,79" class="arrow"/>
-<g id="1645711159">
+<g id="1080201241">
 <rect x="793" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="813" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -2556,45 +2556,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalStringInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="215115584">
-<g id="339664463">
+<g id="1062443404">
+<g id="1910184816">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="1958465847">
+<g id="1562337049">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="713791136">
+<g id="153743099">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="2138785731">
+<g id="1667921683">
 <rect x="335" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="80" text-anchor="middle" class="nonterminal-text">StringReturnType</text>
 </g>
 <line x1="467" y1="76" x2="487" y2="76" class="rail"/>
 <polygon points="474,73 480,76 474,79" class="arrow"/>
-<g id="500507333">
+<g id="1245966485">
 <rect x="487" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="532" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="577" y1="76" x2="597" y2="76" class="rail"/>
 <polygon points="584,73 590,76 584,79" class="arrow"/>
-<g id="936213025">
+<g id="1828952403">
 <rect x="597" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="638" y1="76" x2="658" y2="76" class="rail"/>
 <polygon points="645,73 651,76 645,79" class="arrow"/>
-<g id="1692784210">
-<g id="1090901230">
+<g id="469357745">
+<g id="731642942">
 <rect x="674" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="715" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -2608,7 +2608,7 @@
 </g>
 <line x1="773" y1="76" x2="793" y2="76" class="rail"/>
 <polygon points="780,73 786,76 780,79" class="arrow"/>
-<g id="1351750401">
+<g id="1324042243">
 <rect x="793" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="813" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -2637,45 +2637,45 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExternalObjectInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="1951719176">
-<g id="1671393424">
+<g id="1348323906">
+<g id="1264449620">
 <rect x="40" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="80" text-anchor="middle" class="terminal-text">'external'</text>
 </g>
 <line x1="130" y1="76" x2="150" y2="76" class="rail"/>
 <polygon points="137,73 143,76 137,79" class="arrow"/>
-<g id="696413687">
+<g id="517267922">
 <rect x="150" y="62" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="80" text-anchor="middle" class="terminal-text">'returning'</text>
 </g>
 <line x1="247" y1="76" x2="267" y2="76" class="rail"/>
 <polygon points="254,73 260,76 254,79" class="arrow"/>
-<g id="1774746077">
+<g id="183179611">
 <rect x="267" y="62" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="291" y="80" text-anchor="middle" class="terminal-text">'as'</text>
 </g>
 <line x1="315" y1="76" x2="335" y2="76" class="rail"/>
 <polygon points="322,73 328,76 322,79" class="arrow"/>
-<g id="1983904707">
+<g id="693595763">
 <rect x="335" y="62" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="80" text-anchor="middle" class="nonterminal-text">ObjectReturnType</text>
 </g>
 <line x1="467" y1="76" x2="487" y2="76" class="rail"/>
 <polygon points="474,73 480,76 474,79" class="arrow"/>
-<g id="1857822308">
+<g id="233618517">
 <rect x="487" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="532" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="577" y1="76" x2="597" y2="76" class="rail"/>
 <polygon points="584,73 590,76 584,79" class="arrow"/>
-<g id="1416313745">
+<g id="881788491">
 <rect x="597" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="638" y1="76" x2="658" y2="76" class="rail"/>
 <polygon points="645,73 651,76 645,79" class="arrow"/>
-<g id="1999612856">
-<g id="2118628944">
+<g id="1951018506">
+<g id="1719459904">
 <rect x="674" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="715" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -2689,7 +2689,7 @@
 </g>
 <line x1="773" y1="76" x2="793" y2="76" class="rail"/>
 <polygon points="780,73 786,76 780,79" class="arrow"/>
-<g id="2037306375">
+<g id="481045186">
 <rect x="793" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="813" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -2718,16 +2718,16 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodInvocationHeader</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="711880557">
-<g id="1613040991">
-<g id="929170148">
+<g id="1748574597">
+<g id="931859049">
+<g id="1361207017">
 <rect x="56" y="62" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="87" y="80" text-anchor="middle" class="terminal-text">'call'</text>
 </g>
 <line x1="118" y1="76" x2="138" y2="76" class="rail"/>
 <polygon points="125,73 131,76 125,79" class="arrow"/>
-<g id="853227667">
-<g id="1025121755">
+<g id="154848982">
+<g id="1958547641">
 <rect x="154" y="62" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="199" y="80" text-anchor="middle" class="terminal-text">'internal'</text>
 </g>
@@ -2744,7 +2744,7 @@
 <line x1="260" y1="76" x2="260" y2="76" class="rail"/>
 <line x1="40" y1="76" x2="56" y2="76" class="rail"/>
 <line x1="260" y1="76" x2="276" y2="76" class="rail"/>
-<g id="1199003293">
+<g id="1948110695">
 <rect x="113" y="100" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="158" y="118" text-anchor="middle" class="terminal-text">'internal'</text>
 </g>
@@ -2779,27 +2779,27 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MethodInvocation</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="882561843">
-<g id="1100662035">
+<g id="2048858427">
+<g id="925507114">
 <rect x="40" y="62" width="174" height="28" class="nonterminal-box"/>
 <text x="127" y="80" text-anchor="middle" class="nonterminal-text">MethodInvocationHeader</text>
 </g>
 <line x1="214" y1="76" x2="234" y2="76" class="rail"/>
 <polygon points="221,73 227,76 221,79" class="arrow"/>
-<g id="161314698">
+<g id="1486717668">
 <rect x="234" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="279" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="324" y1="76" x2="344" y2="76" class="rail"/>
 <polygon points="331,73 337,76 331,79" class="arrow"/>
-<g id="1956842394">
+<g id="1113659495">
 <rect x="344" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="364" y="80" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="385" y1="76" x2="405" y2="76" class="rail"/>
 <polygon points="392,73 398,76 392,79" class="arrow"/>
-<g id="977988999">
-<g id="762251108">
+<g id="71935421">
+<g id="1677016231">
 <rect x="421" y="62" width="83" height="28" class="nonterminal-box"/>
 <text x="462" y="80" text-anchor="middle" class="nonterminal-text">Arguments</text>
 </g>
@@ -2813,7 +2813,7 @@
 </g>
 <line x1="520" y1="76" x2="540" y2="76" class="rail"/>
 <polygon points="527,73 533,76 527,79" class="arrow"/>
-<g id="1485438051">
+<g id="813141362">
 <rect x="540" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="560" y="80" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -2842,32 +2842,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ArgumentTernary</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1263455638">
-<g id="1637594851">
+<g id="1465816250">
+<g id="818217691">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="206592386">
+<g id="2045263155">
 <rect x="199" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="219" y="62" text-anchor="middle" class="terminal-text">'?'</text>
 </g>
 <line x1="240" y1="58" x2="260" y2="58" class="rail"/>
 <polygon points="247,55 253,58 247,61" class="arrow"/>
-<g id="455988879">
+<g id="1979196257">
 <rect x="260" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="305" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="350" y1="58" x2="370" y2="58" class="rail"/>
 <polygon points="357,55 363,58 357,61" class="arrow"/>
-<g id="2035064210">
+<g id="2007771684">
 <rect x="370" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="390" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="411" y1="58" x2="431" y2="58" class="rail"/>
 <polygon points="418,55 424,58 418,61" class="arrow"/>
-<g id="1163661558">
+<g id="1877421520">
 <rect x="431" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="476" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
@@ -2896,8 +2896,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ArgumentExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="107034272">
-<g id="1050862558">
+<g id="591234965">
+<g id="1669944859">
 <rect x="56" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="118" y="62" text-anchor="middle" class="nonterminal-text">ArgumentTernary</text>
 </g>
@@ -2905,7 +2905,7 @@
 <line x1="181" y1="58" x2="181" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="181" y1="58" x2="197" y2="58" class="rail"/>
-<g id="589257109">
+<g id="1969401156">
 <rect x="73" y="82" width="90" height="28" class="nonterminal-box"/>
 <text x="118" y="100" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
@@ -2940,22 +2940,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Arguments</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1081011059">
-<g id="1006528903">
+<g id="710142504">
+<g id="6630412">
 <rect x="40" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="113" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="186" y1="58" x2="206" y2="58" class="rail"/>
 <polygon points="193,55 199,58 193,61" class="arrow"/>
-<g id="205582775">
-<g id="1153047286">
-<g id="317444405">
+<g id="796882273">
+<g id="106118379">
+<g id="695573397">
 <rect x="222" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="242" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="263" y1="82" x2="283" y2="82" class="rail"/>
 <polygon points="270,79 276,82 270,85" class="arrow"/>
-<g id="1264709900">
+<g id="1226644338">
 <rect x="283" y="68" width="146" height="28" class="nonterminal-box"/>
 <text x="356" y="86" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
@@ -2999,22 +2999,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1986247810">
-<g id="79928291">
+<g id="877482205">
+<g id="188002971">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">NumberTerm</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="888804702">
-<g id="754884513">
-<g id="272260135">
+<g id="1529265208">
+<g id="1965586540">
+<g id="337601394">
 <rect x="166" y="68" width="55" height="28" class="nonterminal-box"/>
 <text x="193" y="86" text-anchor="middle" class="nonterminal-text">AddOp</text>
 </g>
 <line x1="221" y1="82" x2="241" y2="82" class="rail"/>
 <polygon points="228,79 234,82 228,85" class="arrow"/>
-<g id="469551838">
+<g id="1075828973">
 <rect x="241" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="286" y="86" text-anchor="middle" class="nonterminal-text">NumberTerm</text>
 </g>
@@ -3058,22 +3058,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberTerm</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1480774781">
-<g id="196358826">
+<g id="1432303094">
+<g id="170601993">
 <rect x="40" y="44" width="104" height="28" class="nonterminal-box"/>
 <text x="92" y="62" text-anchor="middle" class="nonterminal-text">NumberFactor</text>
 </g>
 <line x1="144" y1="58" x2="164" y2="58" class="rail"/>
 <polygon points="151,55 157,58 151,61" class="arrow"/>
-<g id="1992060327">
-<g id="1555506681">
-<g id="1408219114">
+<g id="1606563114">
+<g id="214567388">
+<g id="1022811192">
 <rect x="180" y="68" width="55" height="28" class="nonterminal-box"/>
 <text x="207" y="86" text-anchor="middle" class="nonterminal-text">MulOp</text>
 </g>
 <line x1="235" y1="82" x2="255" y2="82" class="rail"/>
 <polygon points="242,79 248,82 242,85" class="arrow"/>
-<g id="937105452">
+<g id="1390371042">
 <rect x="255" y="68" width="104" height="28" class="nonterminal-box"/>
 <text x="307" y="86" text-anchor="middle" class="nonterminal-text">NumberFactor</text>
 </g>
@@ -3117,8 +3117,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AddOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1192116328">
-<g id="926395681">
+<g id="1850994478">
+<g id="2091812815">
 <rect x="56" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="62" text-anchor="middle" class="terminal-text">'+'</text>
 </g>
@@ -3126,7 +3126,7 @@
 <line x1="97" y1="58" x2="97" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="97" y1="58" x2="113" y2="58" class="rail"/>
-<g id="1380634323">
+<g id="544666991">
 <rect x="56" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="100" text-anchor="middle" class="terminal-text">'-'</text>
 </g>
@@ -3161,8 +3161,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MulOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="122492291">
-<g id="153191880">
+<g id="1566419270">
+<g id="1116702615">
 <rect x="56" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="62" text-anchor="middle" class="terminal-text">'*'</text>
 </g>
@@ -3170,7 +3170,7 @@
 <line x1="97" y1="58" x2="97" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="97" y1="58" x2="113" y2="58" class="rail"/>
-<g id="58031976">
+<g id="1251471606">
 <rect x="56" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="100" text-anchor="middle" class="terminal-text">'/'</text>
 </g>
@@ -3205,8 +3205,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MathFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1078775689">
-<g id="854923266">
+<g id="1434148430">
+<g id="738596700">
 <rect x="66" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="62" text-anchor="middle" class="nonterminal-text">SinFunction</text>
 </g>
@@ -3214,7 +3214,7 @@
 <line x1="163" y1="58" x2="174" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="174" y1="58" x2="190" y2="58" class="rail"/>
-<g id="939508817">
+<g id="302751348">
 <rect x="66" y="82" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="100" text-anchor="middle" class="nonterminal-text">CosFunction</text>
 </g>
@@ -3224,7 +3224,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M174,96 Q182,96 182,88" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="534340601">
+<g id="1743707267">
 <rect x="66" y="120" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="138" text-anchor="middle" class="nonterminal-text">TanFunction</text>
 </g>
@@ -3234,7 +3234,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M174,134 Q182,134 182,126" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1884785804">
+<g id="1464426145">
 <rect x="63" y="158" width="104" height="28" class="nonterminal-box"/>
 <text x="115" y="176" text-anchor="middle" class="nonterminal-text">SqrtFunction</text>
 </g>
@@ -3244,7 +3244,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M174,172 Q182,172 182,164" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1786298252">
+<g id="1273565155">
 <rect x="66" y="196" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="214" text-anchor="middle" class="nonterminal-text">MinFunction</text>
 </g>
@@ -3254,7 +3254,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M174,210 Q182,210 182,202" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="602678238">
+<g id="98554068">
 <rect x="66" y="234" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="252" text-anchor="middle" class="nonterminal-text">MaxFunction</text>
 </g>
@@ -3264,7 +3264,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M174,248 Q182,248 182,240" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="2013154033">
+<g id="348397096">
 <rect x="56" y="272" width="118" height="28" class="nonterminal-box"/>
 <text x="115" y="290" text-anchor="middle" class="nonterminal-text">RandomFunction</text>
 </g>
@@ -3274,7 +3274,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M174,286 Q182,286 182,278" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="989956974">
+<g id="166065735">
 <rect x="66" y="310" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="328" text-anchor="middle" class="nonterminal-text">AbsFunction</text>
 </g>
@@ -3284,7 +3284,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M174,324 Q182,324 182,316" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="338351965">
+<g id="183527055">
 <rect x="59" y="348" width="111" height="28" class="nonterminal-box"/>
 <text x="114" y="366" text-anchor="middle" class="nonterminal-text">RoundFunction</text>
 </g>
@@ -3294,7 +3294,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M174,362 Q182,362 182,354" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1452991701">
+<g id="1901219445">
 <rect x="63" y="386" width="104" height="28" class="nonterminal-box"/>
 <text x="115" y="404" text-anchor="middle" class="nonterminal-text">CeilFunction</text>
 </g>
@@ -3304,7 +3304,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M174,400 Q182,400 182,392" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1396086069">
+<g id="1163082537">
 <rect x="59" y="424" width="111" height="28" class="nonterminal-box"/>
 <text x="114" y="442" text-anchor="middle" class="nonterminal-text">FloorFunction</text>
 </g>
@@ -3314,7 +3314,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M174,438 Q182,438 182,430" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="1683697350">
+<g id="1671608842">
 <rect x="66" y="462" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="480" text-anchor="middle" class="nonterminal-text">PowFunction</text>
 </g>
@@ -3324,7 +3324,7 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M174,476 Q182,476 182,468" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="638164271">
+<g id="1794075887">
 <rect x="66" y="500" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="518" text-anchor="middle" class="nonterminal-text">LogFunction</text>
 </g>
@@ -3334,7 +3334,7 @@
 <path d="M48,506 Q48,514 56,514" class="rail" fill="none"/>
 <path d="M174,514 Q182,514 182,506" class="rail" fill="none"/>
 <path d="M182,66 Q182,58 190,58" class="rail" fill="none"/>
-<g id="666134903">
+<g id="162379297">
 <rect x="66" y="538" width="97" height="28" class="nonterminal-box"/>
 <text x="114" y="556" text-anchor="middle" class="nonterminal-text">ExpFunction</text>
 </g>
@@ -3369,26 +3369,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SinFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="803187653">
-<g id="2103243864">
+<g id="81403139">
+<g id="595581953">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'sin'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="399965753">
+<g id="845567125">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="330158693">
+<g id="1453256774">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="901478174">
+<g id="1494765045">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3417,26 +3417,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CosFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="72248965">
-<g id="257474353">
+<g id="804092032">
+<g id="68695025">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'cos'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1922787909">
+<g id="623247348">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="485941391">
+<g id="1045002560">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1319493975">
+<g id="1781488015">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3465,26 +3465,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TanFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1244149221">
-<g id="758052107">
+<g id="1315185668">
+<g id="633202902">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'tan'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="108501689">
+<g id="1355486808">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1731820665">
+<g id="1085853423">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="284429405">
+<g id="72718080">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3513,26 +3513,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SqrtFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="289966311">
-<g id="1890638923">
+<g id="1843390800">
+<g id="1184203334">
 <rect x="40" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="71" y="62" text-anchor="middle" class="terminal-text">'sqrt'</text>
 </g>
 <line x1="102" y1="58" x2="122" y2="58" class="rail"/>
 <polygon points="109,55 115,58 109,61" class="arrow"/>
-<g id="1556524176">
+<g id="1088218061">
 <rect x="122" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="142" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="163" y1="58" x2="183" y2="58" class="rail"/>
 <polygon points="170,55 176,58 170,61" class="arrow"/>
-<g id="1818285489">
+<g id="1746506049">
 <rect x="183" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="1735148229">
+<g id="120773698">
 <rect x="349" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="369" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3561,34 +3561,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MinFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="982781120">
-<g id="2021856370">
+<g id="876140032">
+<g id="1253748141">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'min'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="304389006">
+<g id="1854783010">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="400267621">
+<g id="2144120701">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1599355911">
-<g id="344952642">
-<g id="1107371209">
+<g id="1800499637">
+<g id="1903988640">
+<g id="1842039997">
 <rect x="358" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="378" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="399" y1="82" x2="419" y2="82" class="rail"/>
 <polygon points="406,79 412,82 406,85" class="arrow"/>
-<g id="583112831">
+<g id="1912820588">
 <rect x="419" y="68" width="146" height="28" class="nonterminal-box"/>
 <text x="492" y="86" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
@@ -3609,7 +3609,7 @@
 </g>
 <line x1="581" y1="58" x2="601" y2="58" class="rail"/>
 <polygon points="588,55 594,58 588,61" class="arrow"/>
-<g id="347634760">
+<g id="1556637382">
 <rect x="601" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="621" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3638,34 +3638,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">MaxFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="233991583">
-<g id="1384739151">
+<g id="1761201139">
+<g id="564940456">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'max'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="751029021">
+<g id="1091588081">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="2077145329">
+<g id="1584525123">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1150474396">
-<g id="1242949663">
-<g id="1629903172">
+<g id="2112300187">
+<g id="750640568">
+<g id="747350619">
 <rect x="358" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="378" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="399" y1="82" x2="419" y2="82" class="rail"/>
 <polygon points="406,79 412,82 406,85" class="arrow"/>
-<g id="2017218342">
+<g id="1863411820">
 <rect x="419" y="68" width="146" height="28" class="nonterminal-box"/>
 <text x="492" y="86" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
@@ -3686,7 +3686,7 @@
 </g>
 <line x1="581" y1="58" x2="601" y2="58" class="rail"/>
 <polygon points="588,55 594,58 588,61" class="arrow"/>
-<g id="397235507">
+<g id="214925326">
 <rect x="601" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="621" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3715,20 +3715,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">RandomFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1497339865">
-<g id="1749166382">
+<g id="944993594">
+<g id="711695177">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'random'</text>
 </g>
 <line x1="116" y1="58" x2="136" y2="58" class="rail"/>
 <polygon points="123,55 129,58 123,61" class="arrow"/>
-<g id="977689218">
+<g id="1861001571">
 <rect x="136" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="177" y1="58" x2="197" y2="58" class="rail"/>
 <polygon points="184,55 190,58 184,61" class="arrow"/>
-<g id="1195344948">
+<g id="517182272">
 <rect x="197" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="217" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3757,26 +3757,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">AbsFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2023868543">
-<g id="550358665">
+<g id="169156544">
+<g id="1318322346">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'abs'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="685179480">
+<g id="1165510562">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="334642514">
+<g id="1194558942">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="920052138">
+<g id="1693106855">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3805,26 +3805,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">RoundFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1402824802">
-<g id="1760870641">
+<g id="1930730172">
+<g id="223812727">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'round'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1785620496">
+<g id="1443980662">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1806962502">
+<g id="1683782377">
 <rect x="190" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="488689791">
+<g id="1184203453">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3853,26 +3853,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CeilFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1038292916">
-<g id="1252697321">
+<g id="555655770">
+<g id="779320189">
 <rect x="40" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="71" y="62" text-anchor="middle" class="terminal-text">'ceil'</text>
 </g>
 <line x1="102" y1="58" x2="122" y2="58" class="rail"/>
 <polygon points="109,55 115,58 109,61" class="arrow"/>
-<g id="28269765">
+<g id="696239976">
 <rect x="122" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="142" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="163" y1="58" x2="183" y2="58" class="rail"/>
 <polygon points="170,55 176,58 170,61" class="arrow"/>
-<g id="437766055">
+<g id="1125464208">
 <rect x="183" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="577860351">
+<g id="335776564">
 <rect x="349" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="369" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3901,26 +3901,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">FloorFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="555263205">
-<g id="1179725241">
+<g id="1560342550">
+<g id="1980589462">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'floor'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1650450475">
+<g id="473301631">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1259376661">
+<g id="350511334">
 <rect x="190" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="1852534900">
+<g id="1077681234">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -3949,38 +3949,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">PowFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="414847023">
-<g id="1012614741">
+<g id="1444267267">
+<g id="1896428595">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'pow'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1929701875">
+<g id="1188927908">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1188679479">
+<g id="1713623969">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="570582149">
+<g id="1014566707">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="383" y1="58" x2="403" y2="58" class="rail"/>
 <polygon points="390,55 396,58 390,61" class="arrow"/>
-<g id="1150150526">
+<g id="73993251">
 <rect x="403" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="476" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="549" y1="58" x2="569" y2="58" class="rail"/>
 <polygon points="556,55 562,58 556,61" class="arrow"/>
-<g id="269665645">
+<g id="777237939">
 <rect x="569" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="589" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4009,26 +4009,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LogFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="249331810">
-<g id="699234801">
+<g id="229057415">
+<g id="585193573">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'log'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="45145517">
+<g id="1847939086">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="68114747">
+<g id="1575521876">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1291586301">
+<g id="623732023">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4057,26 +4057,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ExpFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="333841319">
-<g id="176519585">
+<g id="1451384546">
+<g id="1229367069">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'exp'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1950166859">
+<g id="1355094607">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1488615635">
+<g id="504351165">
 <rect x="176" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="839855158">
+<g id="713063136">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4105,38 +4105,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToNumFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1723593854">
-<g id="247214567">
+<g id="1009158790">
+<g id="787296543">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'toNum'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="97233923">
+<g id="1313818462">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1315855888">
+<g id="1739678477">
 <rect x="190" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="256" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="322" y1="58" x2="342" y2="58" class="rail"/>
 <polygon points="329,55 335,58 329,61" class="arrow"/>
-<g id="1840678721">
+<g id="587220055">
 <rect x="342" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="362" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="383" y1="58" x2="403" y2="58" class="rail"/>
 <polygon points="390,55 396,58 390,61" class="arrow"/>
-<g id="40542233">
+<g id="1688399073">
 <rect x="403" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="476" y="62" text-anchor="middle" class="nonterminal-text">ArgumentExpression</text>
 </g>
 <line x1="549" y1="58" x2="569" y2="58" class="rail"/>
 <polygon points="556,55 562,58 556,61" class="arrow"/>
-<g id="1520025571">
+<g id="1357066908">
 <rect x="569" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="589" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4165,8 +4165,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberFactor</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="305630133">
-<g id="1064233831">
+<g id="1800539507">
+<g id="488981417">
 <rect x="113" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="182" y="62" text-anchor="middle" class="nonterminal-text">TernaryExpression</text>
 </g>
@@ -4174,7 +4174,7 @@
 <line x1="252" y1="58" x2="310" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="310" y1="58" x2="326" y2="58" class="rail"/>
-<g id="1750335227">
+<g id="1846767880">
 <rect x="99" y="82" width="167" height="28" class="nonterminal-box"/>
 <text x="182" y="100" text-anchor="middle" class="nonterminal-text">NumberMatchExpression</text>
 </g>
@@ -4184,7 +4184,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M310,96 Q318,96 318,88" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="2141332149">
+<g id="665704836">
 <rect x="131" y="120" width="104" height="28" class="nonterminal-box"/>
 <text x="183" y="138" text-anchor="middle" class="nonterminal-text">IfExpression</text>
 </g>
@@ -4194,7 +4194,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M310,134 Q318,134 318,126" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="1183002939">
+<g id="794232141">
 <rect x="131" y="158" width="104" height="28" class="nonterminal-box"/>
 <text x="183" y="176" text-anchor="middle" class="nonterminal-text">MathFunction</text>
 </g>
@@ -4204,7 +4204,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M310,172 Q318,172 318,164" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="243195743">
+<g id="416822021">
 <rect x="127" y="196" width="111" height="28" class="nonterminal-box"/>
 <text x="182" y="214" text-anchor="middle" class="nonterminal-text">ToNumFunction</text>
 </g>
@@ -4214,7 +4214,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M310,210 Q318,210 318,202" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="2041400397">
+<g id="1840679463">
 <rect x="120" y="234" width="125" height="28" class="nonterminal-box"/>
 <text x="182" y="252" text-anchor="middle" class="nonterminal-text">LengthDotMethod</text>
 </g>
@@ -4224,7 +4224,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M310,248 Q318,248 318,240" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="393506375">
+<g id="605954028">
 <rect x="134" y="272" width="97" height="28" class="nonterminal-box"/>
 <text x="182" y="290" text-anchor="middle" class="nonterminal-text">LenFunction</text>
 </g>
@@ -4234,7 +4234,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M310,286 Q318,286 318,278" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="1210163067">
+<g id="871635791">
 <rect x="124" y="310" width="118" height="28" class="nonterminal-box"/>
 <text x="183" y="328" text-anchor="middle" class="nonterminal-text">LengthFunction</text>
 </g>
@@ -4244,7 +4244,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M310,324 Q318,324 318,316" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="819799303">
+<g id="1793934895">
 <rect x="89" y="348" width="188" height="28" class="nonterminal-box"/>
 <text x="183" y="366" text-anchor="middle" class="nonterminal-text">ExternalNumberInvocation</text>
 </g>
@@ -4254,7 +4254,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M310,362 Q318,362 318,354" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="595712117">
+<g id="869474023">
 <rect x="152" y="386" width="62" height="28" class="nonterminal-box"/>
 <text x="183" y="404" text-anchor="middle" class="nonterminal-text">NUMBER</text>
 </g>
@@ -4264,7 +4264,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M310,400 Q318,400 318,392" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="397642772">
+<g id="1734776334">
 <rect x="134" y="424" width="97" height="28" class="nonterminal-box"/>
 <text x="182" y="442" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -4274,7 +4274,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M310,438 Q318,438 318,430" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="1403851742">
+<g id="1960560590">
 <rect x="117" y="462" width="132" height="28" class="nonterminal-box"/>
 <text x="183" y="480" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -4284,20 +4284,20 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M310,476 Q318,476 318,468" class="rail" fill="none"/>
 <path d="M318,66 Q318,58 326,58" class="rail" fill="none"/>
-<g id="398392474">
-<g id="167895473">
+<g id="641884148">
+<g id="1946626884">
 <rect x="56" y="500" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="518" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="97" y1="514" x2="117" y2="514" class="rail"/>
 <polygon points="104,511 110,514 104,517" class="arrow"/>
-<g id="661570292">
+<g id="1594369797">
 <rect x="117" y="500" width="132" height="28" class="nonterminal-box"/>
 <text x="183" y="518" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="249" y1="514" x2="269" y2="514" class="rail"/>
 <polygon points="256,511 262,514 256,517" class="arrow"/>
-<g id="741746977">
+<g id="202185740">
 <rect x="269" y="500" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="289" y="518" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4333,26 +4333,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToUpperCaseFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="800080894">
-<g id="1134531173">
+<g id="1244553411">
+<g id="1971076883">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'toUpperCase'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="1585304598">
+<g id="292921548">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="1044883823">
+<g id="637333737">
 <rect x="232" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="298" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="364" y1="58" x2="384" y2="58" class="rail"/>
 <polygon points="371,55 377,58 371,61" class="arrow"/>
-<g id="277079857">
+<g id="1581140144">
 <rect x="384" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="404" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4381,26 +4381,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToLowerCaseFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1311991619">
-<g id="534638458">
+<g id="1507023485">
+<g id="1986120330">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'toLowerCase'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="483537215">
+<g id="878188311">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="333965307">
+<g id="412070628">
 <rect x="232" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="298" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="364" y1="58" x2="384" y2="58" class="rail"/>
 <polygon points="371,55 377,58 371,61" class="arrow"/>
-<g id="1046866378">
+<g id="555671886">
 <rect x="384" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="404" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4429,26 +4429,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TrimFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1193120474">
-<g id="1139145843">
+<g id="1209983319">
+<g id="759635711">
 <rect x="40" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="71" y="62" text-anchor="middle" class="terminal-text">'trim'</text>
 </g>
 <line x1="102" y1="58" x2="122" y2="58" class="rail"/>
 <polygon points="109,55 115,58 109,61" class="arrow"/>
-<g id="1871774667">
+<g id="1211797793">
 <rect x="122" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="142" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="163" y1="58" x2="183" y2="58" class="rail"/>
 <polygon points="170,55 176,58 170,61" class="arrow"/>
-<g id="2116787274">
+<g id="511188473">
 <rect x="183" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="737670579">
+<g id="1572580601">
 <rect x="335" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4477,26 +4477,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LengthFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="930751215">
-<g id="544562857">
+<g id="1878224161">
+<g id="1412551404">
 <rect x="40" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="78" y="62" text-anchor="middle" class="terminal-text">'length'</text>
 </g>
 <line x1="116" y1="58" x2="136" y2="58" class="rail"/>
 <polygon points="123,55 129,58 123,61" class="arrow"/>
-<g id="35544865">
+<g id="175675974">
 <rect x="136" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="177" y1="58" x2="197" y2="58" class="rail"/>
 <polygon points="184,55 190,58 184,61" class="arrow"/>
-<g id="382761148">
+<g id="178533268">
 <rect x="197" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="263" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="1030796286">
+<g id="898592718">
 <rect x="349" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="369" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4525,26 +4525,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LenFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="659846761">
-<g id="1206748278">
+<g id="710492053">
+<g id="555180083">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'len'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1382879663">
+<g id="176475926">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1782232927">
+<g id="1153118359">
 <rect x="176" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="242" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="308" y1="58" x2="328" y2="58" class="rail"/>
 <polygon points="315,55 321,58 315,61" class="arrow"/>
-<g id="204578221">
+<g id="819316548">
 <rect x="328" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="348" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4573,26 +4573,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToUpperCaseDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1286624439">
-<g id="495909701">
+<g id="756285027">
+<g id="101300663">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="573650916">
+<g id="464199273">
 <rect x="157" y="44" width="118" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="216" y="62" text-anchor="middle" class="terminal-text">'.toUpperCase'</text>
 </g>
 <line x1="275" y1="58" x2="295" y2="58" class="rail"/>
 <polygon points="282,55 288,58 282,61" class="arrow"/>
-<g id="585964282">
+<g id="89789887">
 <rect x="295" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="315" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="646891504">
+<g id="1713121046">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4621,26 +4621,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ToLowerCaseDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2049268765">
-<g id="1737872594">
+<g id="668333245">
+<g id="1846081022">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="769992720">
+<g id="992666221">
 <rect x="157" y="44" width="118" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="216" y="62" text-anchor="middle" class="terminal-text">'.toLowerCase'</text>
 </g>
 <line x1="275" y1="58" x2="295" y2="58" class="rail"/>
 <polygon points="282,55 288,58 282,61" class="arrow"/>
-<g id="2105858843">
+<g id="1007240841">
 <rect x="295" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="315" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="870268400">
+<g id="240867213">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4669,26 +4669,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TrimDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1673775560">
-<g id="2122604257">
+<g id="685020433">
+<g id="1258308512">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="620957225">
+<g id="1036740935">
 <rect x="157" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'.trim'</text>
 </g>
 <line x1="226" y1="58" x2="246" y2="58" class="rail"/>
 <polygon points="233,55 239,58 233,61" class="arrow"/>
-<g id="1870239684">
+<g id="1777907276">
 <rect x="246" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="266" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="287" y1="58" x2="307" y2="58" class="rail"/>
 <polygon points="294,55 300,58 294,61" class="arrow"/>
-<g id="1072495490">
+<g id="1627441106">
 <rect x="307" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="327" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4717,26 +4717,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">LengthDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1632325264">
-<g id="1577902559">
+<g id="1570491305">
+<g id="1311985693">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="2112395885">
+<g id="1649792321">
 <rect x="157" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="198" y="62" text-anchor="middle" class="terminal-text">'.length'</text>
 </g>
 <line x1="240" y1="58" x2="260" y2="58" class="rail"/>
 <polygon points="247,55 253,58 247,61" class="arrow"/>
-<g id="620777145">
+<g id="84713614">
 <rect x="260" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="280" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="301" y1="58" x2="321" y2="58" class="rail"/>
 <polygon points="308,55 314,58 308,61" class="arrow"/>
-<g id="1483759192">
+<g id="159174947">
 <rect x="321" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="341" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4765,38 +4765,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StartsWithFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="278447004">
-<g id="1481214758">
+<g id="1967624519">
+<g id="287896198">
 <rect x="40" y="44" width="104" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="92" y="62" text-anchor="middle" class="terminal-text">'startsWith'</text>
 </g>
 <line x1="144" y1="58" x2="164" y2="58" class="rail"/>
 <polygon points="151,55 157,58 151,61" class="arrow"/>
-<g id="2140893968">
+<g id="1908422909">
 <rect x="164" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="184" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="205" y1="58" x2="225" y2="58" class="rail"/>
 <polygon points="212,55 218,58 212,61" class="arrow"/>
-<g id="633565221">
+<g id="509217327">
 <rect x="225" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="291" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="357" y1="58" x2="377" y2="58" class="rail"/>
 <polygon points="364,55 370,58 364,61" class="arrow"/>
-<g id="516392387">
+<g id="496979150">
 <rect x="377" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="397" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="418" y1="58" x2="438" y2="58" class="rail"/>
 <polygon points="425,55 431,58 425,61" class="arrow"/>
-<g id="180563334">
+<g id="1274360121">
 <rect x="438" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="504" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="570" y1="58" x2="590" y2="58" class="rail"/>
 <polygon points="577,55 583,58 577,61" class="arrow"/>
-<g id="786750525">
+<g id="998440810">
 <rect x="590" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="610" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4825,38 +4825,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">EndsWithFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="824668987">
-<g id="844346833">
+<g id="1331067291">
+<g id="307845661">
 <rect x="40" y="44" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="terminal-text">'endsWith'</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="569311488">
+<g id="1883753878">
 <rect x="150" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="702690356">
+<g id="1553073499">
 <rect x="211" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="277" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="343" y1="58" x2="363" y2="58" class="rail"/>
 <polygon points="350,55 356,58 350,61" class="arrow"/>
-<g id="2142279351">
+<g id="353790503">
 <rect x="363" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="383" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="404" y1="58" x2="424" y2="58" class="rail"/>
 <polygon points="411,55 417,58 411,61" class="arrow"/>
-<g id="1357007277">
+<g id="1304908586">
 <rect x="424" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="490" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="556" y1="58" x2="576" y2="58" class="rail"/>
 <polygon points="563,55 569,58 563,61" class="arrow"/>
-<g id="157066672">
+<g id="52563065">
 <rect x="576" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="596" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4885,38 +4885,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ContainsFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1753690872">
-<g id="1247370886">
+<g id="612485105">
+<g id="1773626628">
 <rect x="40" y="44" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="terminal-text">'contains'</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="146069825">
+<g id="513680667">
 <rect x="150" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="1680444610">
+<g id="223130485">
 <rect x="211" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="277" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="343" y1="58" x2="363" y2="58" class="rail"/>
 <polygon points="350,55 356,58 350,61" class="arrow"/>
-<g id="1855817175">
+<g id="1898613222">
 <rect x="363" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="383" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="404" y1="58" x2="424" y2="58" class="rail"/>
 <polygon points="411,55 417,58 411,61" class="arrow"/>
-<g id="1857051628">
+<g id="602361218">
 <rect x="424" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="490" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="556" y1="58" x2="576" y2="58" class="rail"/>
 <polygon points="563,55 569,58 563,61" class="arrow"/>
-<g id="1080097194">
+<g id="1279136280">
 <rect x="576" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="596" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -4945,40 +4945,40 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">InMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1436324046">
-<g id="1781969154">
+<g id="1383051965">
+<g id="21040958">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="112584851">
+<g id="408148425">
 <rect x="192" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="219" y="62" text-anchor="middle" class="terminal-text">'.in'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="1105198150">
+<g id="616674825">
 <rect x="267" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="287" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="308" y1="58" x2="328" y2="58" class="rail"/>
 <polygon points="315,55 321,58 315,61" class="arrow"/>
-<g id="278795895">
+<g id="248861487">
 <rect x="328" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="394" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="460" y1="58" x2="480" y2="58" class="rail"/>
 <polygon points="467,55 473,58 467,61" class="arrow"/>
-<g id="946468440">
-<g id="1487175317">
-<g id="1342114759">
+<g id="206529624">
+<g id="682038856">
+<g id="132420916">
 <rect x="496" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="516" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="537" y1="82" x2="557" y2="82" class="rail"/>
 <polygon points="544,79 550,82 544,85" class="arrow"/>
-<g id="1713869787">
+<g id="25139600">
 <rect x="557" y="68" width="132" height="28" class="nonterminal-box"/>
 <text x="623" y="86" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -4999,7 +4999,7 @@
 </g>
 <line x1="705" y1="58" x2="725" y2="58" class="rail"/>
 <polygon points="712,55 718,58 712,61" class="arrow"/>
-<g id="268399521">
+<g id="790699472">
 <rect x="725" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="745" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5028,32 +5028,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StartsWithDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="215960248">
-<g id="783752254">
+<g id="486211780">
+<g id="1122692078">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="1503392902">
+<g id="904931919">
 <rect x="157" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="212" y="62" text-anchor="middle" class="terminal-text">'.startsWith'</text>
 </g>
 <line x1="268" y1="58" x2="288" y2="58" class="rail"/>
 <polygon points="275,55 281,58 275,61" class="arrow"/>
-<g id="764278383">
+<g id="303595196">
 <rect x="288" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="308" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="329" y1="58" x2="349" y2="58" class="rail"/>
 <polygon points="336,55 342,58 336,61" class="arrow"/>
-<g id="472259056">
+<g id="1028512792">
 <rect x="349" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="415" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="481" y1="58" x2="501" y2="58" class="rail"/>
 <polygon points="488,55 494,58 488,61" class="arrow"/>
-<g id="182886566">
+<g id="686679492">
 <rect x="501" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="521" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5082,32 +5082,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">EndsWithDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="743040281">
-<g id="1310976962">
+<g id="999913186">
+<g id="1304916089">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="1659277935">
+<g id="515496133">
 <rect x="157" y="44" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="205" y="62" text-anchor="middle" class="terminal-text">'.endsWith'</text>
 </g>
 <line x1="254" y1="58" x2="274" y2="58" class="rail"/>
 <polygon points="261,55 267,58 261,61" class="arrow"/>
-<g id="1572531461">
+<g id="1505615123">
 <rect x="274" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="294" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="726070912">
+<g id="495197120">
 <rect x="335" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="467" y1="58" x2="487" y2="58" class="rail"/>
 <polygon points="474,55 480,58 474,61" class="arrow"/>
-<g id="2053793233">
+<g id="1798759601">
 <rect x="487" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="507" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5136,32 +5136,32 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ContainsDotMethod</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="479713637">
-<g id="647096144">
+<g id="443482771">
+<g id="217801159">
 <rect x="40" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="989853684">
+<g id="832315779">
 <rect x="157" y="44" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="205" y="62" text-anchor="middle" class="terminal-text">'.contains'</text>
 </g>
 <line x1="254" y1="58" x2="274" y2="58" class="rail"/>
 <polygon points="261,55 267,58 261,61" class="arrow"/>
-<g id="319969687">
+<g id="1842567277">
 <rect x="274" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="294" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="1888487361">
+<g id="487398739">
 <rect x="335" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="401" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="467" y1="58" x2="487" y2="58" class="rail"/>
 <polygon points="474,55 480,58 474,61" class="arrow"/>
-<g id="1494402532">
+<g id="1244635756">
 <rect x="487" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="507" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5190,26 +5190,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">IsPresentFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1520706274">
-<g id="491320705">
+<g id="1629512617">
+<g id="1837642115">
 <rect x="40" y="44" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="88" y="62" text-anchor="middle" class="terminal-text">'isPresent'</text>
 </g>
 <line x1="137" y1="58" x2="157" y2="58" class="rail"/>
 <polygon points="144,55 150,58 144,61" class="arrow"/>
-<g id="1830176742">
+<g id="412770020">
 <rect x="157" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="177" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="198" y1="58" x2="218" y2="58" class="rail"/>
 <polygon points="205,55 211,58 205,61" class="arrow"/>
-<g id="585404997">
+<g id="798077785">
 <rect x="218" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="266" y="62" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="10103693">
+<g id="1292388258">
 <rect x="335" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5238,38 +5238,38 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">InTimeRangeFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1381493051">
-<g id="89290535">
+<g id="675584911">
+<g id="721910807">
 <rect x="40" y="44" width="111" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="terminal-text">'inTimeRange'</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="60992370">
+<g id="154011989">
 <rect x="171" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="191" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="212" y1="58" x2="232" y2="58" class="rail"/>
 <polygon points="219,55 225,58 219,61" class="arrow"/>
-<g id="1379217096">
+<g id="102001285">
 <rect x="232" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="298" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="364" y1="58" x2="384" y2="58" class="rail"/>
 <polygon points="371,55 377,58 371,61" class="arrow"/>
-<g id="704488798">
+<g id="1682668741">
 <rect x="384" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="404" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="425" y1="58" x2="445" y2="58" class="rail"/>
 <polygon points="432,55 438,58 432,61" class="arrow"/>
-<g id="1056965641">
+<g id="1958499231">
 <rect x="445" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="511" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="577" y1="58" x2="597" y2="58" class="rail"/>
 <polygon points="584,55 590,58 584,61" class="arrow"/>
-<g id="703578528">
+<g id="228694268">
 <rect x="597" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="617" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5298,62 +5298,62 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">InDayTimeRangeFunction</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1449651851">
-<g id="373584250">
+<g id="6182312">
+<g id="399931158">
 <rect x="40" y="44" width="132" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="terminal-text">'inDayTimeRange'</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="693837815">
+<g id="23129816">
 <rect x="192" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="212" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="233" y1="58" x2="253" y2="58" class="rail"/>
 <polygon points="240,55 246,58 240,61" class="arrow"/>
-<g id="2129541565">
+<g id="520304">
 <rect x="253" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="294" y="62" text-anchor="middle" class="nonterminal-text">DayOfWeek</text>
 </g>
 <line x1="336" y1="58" x2="356" y2="58" class="rail"/>
 <polygon points="343,55 349,58 343,61" class="arrow"/>
-<g id="329062762">
+<g id="202607388">
 <rect x="356" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="376" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="397" y1="58" x2="417" y2="58" class="rail"/>
 <polygon points="404,55 410,58 404,61" class="arrow"/>
-<g id="644314562">
+<g id="676934479">
 <rect x="417" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="483" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="549" y1="58" x2="569" y2="58" class="rail"/>
 <polygon points="556,55 562,58 556,61" class="arrow"/>
-<g id="1462923870">
+<g id="776543922">
 <rect x="569" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="589" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="610" y1="58" x2="630" y2="58" class="rail"/>
 <polygon points="617,55 623,58 617,61" class="arrow"/>
-<g id="1478400724">
+<g id="301137787">
 <rect x="630" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="671" y="62" text-anchor="middle" class="nonterminal-text">DayOfWeek</text>
 </g>
 <line x1="713" y1="58" x2="733" y2="58" class="rail"/>
 <polygon points="720,55 726,58 720,61" class="arrow"/>
-<g id="598974196">
+<g id="27905330">
 <rect x="733" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="753" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="774" y1="58" x2="794" y2="58" class="rail"/>
 <polygon points="781,55 787,58 781,61" class="arrow"/>
-<g id="1046951461">
+<g id="1611355395">
 <rect x="794" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="860" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="926" y1="58" x2="946" y2="58" class="rail"/>
 <polygon points="933,55 939,58 933,61" class="arrow"/>
-<g id="2055410485">
+<g id="106003262">
 <rect x="946" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="966" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -5382,8 +5382,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">DayOfWeek</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1356601834">
-<g id="1771871885">
+<g id="44840797">
+<g id="1330759884">
 <rect x="66" y="44" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="62" text-anchor="middle" class="terminal-text">'MONDAY'</text>
 </g>
@@ -5391,7 +5391,7 @@
 <line x1="142" y1="58" x2="153" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="153" y1="58" x2="169" y2="58" class="rail"/>
-<g id="1850559365">
+<g id="1967669096">
 <rect x="63" y="82" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="100" text-anchor="middle" class="terminal-text">'TUESDAY'</text>
 </g>
@@ -5401,7 +5401,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M153,96 Q161,96 161,88" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="204863426">
+<g id="2018325108">
 <rect x="56" y="120" width="97" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="138" text-anchor="middle" class="terminal-text">'WEDNESDAY'</text>
 </g>
@@ -5411,7 +5411,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M153,134 Q161,134 161,126" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1699693433">
+<g id="172805056">
 <rect x="59" y="158" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="176" text-anchor="middle" class="terminal-text">'THURSDAY'</text>
 </g>
@@ -5421,7 +5421,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M153,172 Q161,172 161,164" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1747632555">
+<g id="1260025325">
 <rect x="66" y="196" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="214" text-anchor="middle" class="terminal-text">'FRIDAY'</text>
 </g>
@@ -5431,7 +5431,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M153,210 Q161,210 161,202" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1824501320">
+<g id="2141040793">
 <rect x="59" y="234" width="90" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="252" text-anchor="middle" class="terminal-text">'SATURDAY'</text>
 </g>
@@ -5441,7 +5441,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M153,248 Q161,248 161,240" class="rail" fill="none"/>
 <path d="M161,66 Q161,58 169,58" class="rail" fill="none"/>
-<g id="1326960634">
+<g id="1859318668">
 <rect x="66" y="272" width="76" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="104" y="290" text-anchor="middle" class="terminal-text">'SUNDAY'</text>
 </g>
@@ -5476,8 +5476,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceBaseReceiver</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2037323343">
-<g id="1850064323">
+<g id="839850431">
+<g id="444698616">
 <rect x="73" y="44" width="188" height="28" class="nonterminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="nonterminal-text">ExternalStringInvocation</text>
 </g>
@@ -5485,7 +5485,7 @@
 <line x1="261" y1="58" x2="279" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="279" y1="58" x2="295" y2="58" class="rail"/>
-<g id="2132382637">
+<g id="134933833">
 <rect x="56" y="82" width="223" height="28" class="nonterminal-box"/>
 <text x="167" y="100" text-anchor="middle" class="nonterminal-text">ParenthesizedStringExpression</text>
 </g>
@@ -5495,7 +5495,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M279,96 Q287,96 287,88" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="243334059">
+<g id="1899831639">
 <rect x="91" y="120" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="138" text-anchor="middle" class="nonterminal-text">ToUpperCaseFunction</text>
 </g>
@@ -5505,7 +5505,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M279,134 Q287,134 287,126" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1050910936">
+<g id="315160306">
 <rect x="91" y="158" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="176" text-anchor="middle" class="nonterminal-text">ToLowerCaseFunction</text>
 </g>
@@ -5515,7 +5515,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M279,172 Q287,172 287,164" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="2102110570">
+<g id="69223708">
 <rect x="115" y="196" width="104" height="28" class="nonterminal-box"/>
 <text x="167" y="214" text-anchor="middle" class="nonterminal-text">TrimFunction</text>
 </g>
@@ -5525,7 +5525,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M279,210 Q287,210 287,202" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1325193621">
+<g id="1537179764">
 <rect x="87" y="234" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="252" text-anchor="middle" class="nonterminal-text">ToUpperCaseDotMethod</text>
 </g>
@@ -5535,7 +5535,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M279,248 Q287,248 287,240" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1202204226">
+<g id="1135621577">
 <rect x="87" y="272" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="290" text-anchor="middle" class="nonterminal-text">ToLowerCaseDotMethod</text>
 </g>
@@ -5545,7 +5545,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M279,286 Q287,286 287,278" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1680794383">
+<g id="379204651">
 <rect x="112" y="310" width="111" height="28" class="nonterminal-box"/>
 <text x="167" y="328" text-anchor="middle" class="nonterminal-text">TrimDotMethod</text>
 </g>
@@ -5555,7 +5555,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M279,324 Q287,324 287,316" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1141773849">
+<g id="278170433">
 <rect x="136" y="348" width="62" height="28" class="nonterminal-box"/>
 <text x="167" y="366" text-anchor="middle" class="nonterminal-text">STRING</text>
 </g>
@@ -5565,7 +5565,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M279,362 Q287,362 287,354" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1821794172">
+<g id="925836551">
 <rect x="119" y="386" width="97" height="28" class="nonterminal-box"/>
 <text x="167" y="404" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -5575,7 +5575,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M279,400 Q287,400 287,392" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1783277202">
+<g id="1970491478">
 <rect x="101" y="424" width="132" height="28" class="nonterminal-box"/>
 <text x="167" y="442" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -5610,51 +5610,51 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceBaseExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="657932075">
-<g id="1872375138">
-<g id="1306880421">
+<g id="160823881">
+<g id="819590990">
+<g id="116736572">
 <rect x="56" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="125" y="62" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="195" y1="58" x2="215" y2="58" class="rail"/>
 <polygon points="202,55 208,58 202,61" class="arrow"/>
-<g id="332833498">
+<g id="1211910392">
 <rect x="215" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="235" y="62" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="256" y1="58" x2="276" y2="58" class="rail"/>
 <polygon points="263,55 269,58 263,61" class="arrow"/>
-<g id="739768324">
+<g id="664948809">
 <rect x="276" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="342" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="408" y1="58" x2="428" y2="58" class="rail"/>
 <polygon points="415,55 421,58 415,61" class="arrow"/>
-<g id="759910055">
+<g id="1839888355">
 <rect x="428" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="448" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="469" y1="58" x2="489" y2="58" class="rail"/>
 <polygon points="476,55 482,58 476,61" class="arrow"/>
-<g id="1258664682">
+<g id="1096953032">
 <rect x="489" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="555" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="621" y1="58" x2="641" y2="58" class="rail"/>
 <polygon points="628,55 634,58 628,61" class="arrow"/>
-<g id="1843595554">
+<g id="1806944148">
 <rect x="641" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="661" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="682" y1="58" x2="702" y2="58" class="rail"/>
 <polygon points="689,55 695,58 689,61" class="arrow"/>
-<g id="2124876610">
+<g id="1587999411">
 <rect x="702" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="768" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="834" y1="58" x2="854" y2="58" class="rail"/>
 <polygon points="841,55 847,58 841,61" class="arrow"/>
-<g id="158227527">
+<g id="1611498475">
 <rect x="854" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="874" y="62" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5663,38 +5663,38 @@
 <line x1="895" y1="58" x2="895" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="895" y1="58" x2="911" y2="58" class="rail"/>
-<g id="1803991339">
-<g id="440767402">
+<g id="2018110225">
+<g id="1168316838">
 <rect x="162" y="82" width="139" height="28" class="nonterminal-box"/>
 <text x="231" y="100" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="301" y1="96" x2="321" y2="96" class="rail"/>
 <polygon points="308,93 314,96 308,99" class="arrow"/>
-<g id="1551791803">
+<g id="754538699">
 <rect x="321" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="341" y="100" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="362" y1="96" x2="382" y2="96" class="rail"/>
 <polygon points="369,93 375,96 369,99" class="arrow"/>
-<g id="663323927">
+<g id="543655012">
 <rect x="382" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="448" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="514" y1="96" x2="534" y2="96" class="rail"/>
 <polygon points="521,93 527,96 521,99" class="arrow"/>
-<g id="432430521">
+<g id="1610310817">
 <rect x="534" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="554" y="100" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="575" y1="96" x2="595" y2="96" class="rail"/>
 <polygon points="582,93 588,96 582,99" class="arrow"/>
-<g id="791168488">
+<g id="38287569">
 <rect x="595" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="661" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="727" y1="96" x2="747" y2="96" class="rail"/>
 <polygon points="734,93 740,96 734,99" class="arrow"/>
-<g id="13378840">
+<g id="1678837587">
 <rect x="747" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="767" y="100" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5705,44 +5705,44 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M895,96 Q903,96 903,88" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="2080392919">
-<g id="1082530423">
+<g id="1253396039">
+<g id="2090030805">
 <rect x="132" y="120" width="139" height="28" class="nonterminal-box"/>
 <text x="201" y="138" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="271" y1="134" x2="291" y2="134" class="rail"/>
 <polygon points="278,131 284,134 278,137" class="arrow"/>
-<g id="770441354">
+<g id="1063151398">
 <rect x="291" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="311" y="138" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="332" y1="134" x2="352" y2="134" class="rail"/>
 <polygon points="339,131 345,134 339,137" class="arrow"/>
-<g id="1281955018">
+<g id="1402590209">
 <rect x="352" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="418" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="484" y1="134" x2="504" y2="134" class="rail"/>
 <polygon points="491,131 497,134 491,137" class="arrow"/>
-<g id="318284685">
+<g id="1690287104">
 <rect x="504" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="524" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="545" y1="134" x2="565" y2="134" class="rail"/>
 <polygon points="552,131 558,134 552,137" class="arrow"/>
-<g id="1650284039">
+<g id="41712572">
 <rect x="565" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="585" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="606" y1="134" x2="626" y2="134" class="rail"/>
 <polygon points="613,131 619,134 613,137" class="arrow"/>
-<g id="796455574">
+<g id="1322732418">
 <rect x="626" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="692" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="758" y1="134" x2="778" y2="134" class="rail"/>
 <polygon points="765,131 771,134 765,137" class="arrow"/>
-<g id="724794615">
+<g id="1408481157">
 <rect x="778" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="798" y="138" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5753,32 +5753,32 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M895,134 Q903,134 903,126" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="528898437">
-<g id="1961216574">
+<g id="2071232307">
+<g id="737504566">
 <rect x="238" y="158" width="139" height="28" class="nonterminal-box"/>
 <text x="307" y="176" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="377" y1="172" x2="397" y2="172" class="rail"/>
 <polygon points="384,169 390,172 384,175" class="arrow"/>
-<g id="484534902">
+<g id="1594538129">
 <rect x="397" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="417" y="176" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="438" y1="172" x2="458" y2="172" class="rail"/>
 <polygon points="445,169 451,172 445,175" class="arrow"/>
-<g id="738552281">
+<g id="285959018">
 <rect x="458" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="524" y="176" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="590" y1="172" x2="610" y2="172" class="rail"/>
 <polygon points="597,169 603,172 597,175" class="arrow"/>
-<g id="1380824176">
+<g id="1907150970">
 <rect x="610" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="630" y="176" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="651" y1="172" x2="671" y2="172" class="rail"/>
 <polygon points="658,169 664,172 658,175" class="arrow"/>
-<g id="144908349">
+<g id="1907400612">
 <rect x="671" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="691" y="176" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5789,44 +5789,44 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M895,172 Q903,172 903,164" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1048521843">
-<g id="407547917">
+<g id="779910007">
+<g id="825115396">
 <rect x="132" y="196" width="139" height="28" class="nonterminal-box"/>
 <text x="201" y="214" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="271" y1="210" x2="291" y2="210" class="rail"/>
 <polygon points="278,207 284,210 278,213" class="arrow"/>
-<g id="656111936">
+<g id="639007323">
 <rect x="291" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="311" y="214" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="332" y1="210" x2="352" y2="210" class="rail"/>
 <polygon points="339,207 345,210 339,213" class="arrow"/>
-<g id="908597078">
+<g id="1395563650">
 <rect x="352" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="372" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="393" y1="210" x2="413" y2="210" class="rail"/>
 <polygon points="400,207 406,210 400,213" class="arrow"/>
-<g id="458177127">
+<g id="201059379">
 <rect x="413" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="479" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="545" y1="210" x2="565" y2="210" class="rail"/>
 <polygon points="552,207 558,210 552,213" class="arrow"/>
-<g id="1447574491">
+<g id="1208920107">
 <rect x="565" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="585" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="606" y1="210" x2="626" y2="210" class="rail"/>
 <polygon points="613,207 619,210 613,213" class="arrow"/>
-<g id="711301419">
+<g id="1574946771">
 <rect x="626" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="692" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="758" y1="210" x2="778" y2="210" class="rail"/>
 <polygon points="765,207 771,210 765,213" class="arrow"/>
-<g id="1543616918">
+<g id="2058521190">
 <rect x="778" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="798" y="214" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5837,32 +5837,32 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M895,210 Q903,210 903,202" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1814718277">
-<g id="704532100">
+<g id="632992434">
+<g id="319738211">
 <rect x="238" y="234" width="139" height="28" class="nonterminal-box"/>
 <text x="307" y="252" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="377" y1="248" x2="397" y2="248" class="rail"/>
 <polygon points="384,245 390,248 384,251" class="arrow"/>
-<g id="802436689">
+<g id="810319246">
 <rect x="397" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="417" y="252" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="438" y1="248" x2="458" y2="248" class="rail"/>
 <polygon points="445,245 451,248 445,251" class="arrow"/>
-<g id="2118711092">
+<g id="1589846107">
 <rect x="458" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="478" y="252" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="499" y1="248" x2="519" y2="248" class="rail"/>
 <polygon points="506,245 512,248 506,251" class="arrow"/>
-<g id="957567034">
+<g id="321474359">
 <rect x="519" y="234" width="132" height="28" class="nonterminal-box"/>
 <text x="585" y="252" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="651" y1="248" x2="671" y2="248" class="rail"/>
 <polygon points="658,245 664,248 658,251" class="arrow"/>
-<g id="1656927218">
+<g id="1984496120">
 <rect x="671" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="691" y="252" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5873,38 +5873,38 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M895,248 Q903,248 903,240" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1495052294">
-<g id="1440930979">
+<g id="156617115">
+<g id="1648140198">
 <rect x="208" y="272" width="139" height="28" class="nonterminal-box"/>
 <text x="277" y="290" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="347" y1="286" x2="367" y2="286" class="rail"/>
 <polygon points="354,283 360,286 354,289" class="arrow"/>
-<g id="1993594021">
+<g id="993338401">
 <rect x="367" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="387" y="290" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="408" y1="286" x2="428" y2="286" class="rail"/>
 <polygon points="415,283 421,286 415,289" class="arrow"/>
-<g id="33137838">
+<g id="97367166">
 <rect x="428" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="448" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="469" y1="286" x2="489" y2="286" class="rail"/>
 <polygon points="476,283 482,286 476,289" class="arrow"/>
-<g id="1045887899">
+<g id="1972549975">
 <rect x="489" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="509" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="530" y1="286" x2="550" y2="286" class="rail"/>
 <polygon points="537,283 543,286 537,289" class="arrow"/>
-<g id="2106732342">
+<g id="1935006188">
 <rect x="550" y="272" width="132" height="28" class="nonterminal-box"/>
 <text x="616" y="290" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="682" y1="286" x2="702" y2="286" class="rail"/>
 <polygon points="689,283 695,286 689,289" class="arrow"/>
-<g id="353151709">
+<g id="1632890763">
 <rect x="702" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="722" y="290" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5915,26 +5915,26 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M895,286 Q903,286 903,278" class="rail" fill="none"/>
 <path d="M903,66 Q903,58 911,58" class="rail" fill="none"/>
-<g id="1488034126">
-<g id="1352602269">
+<g id="1747117589">
+<g id="1777177063">
 <rect x="314" y="310" width="139" height="28" class="nonterminal-box"/>
 <text x="383" y="328" text-anchor="middle" class="nonterminal-text">SliceBaseReceiver</text>
 </g>
 <line x1="453" y1="324" x2="473" y2="324" class="rail"/>
 <polygon points="460,321 466,324 460,327" class="arrow"/>
-<g id="1016622119">
+<g id="883601295">
 <rect x="473" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="493" y="328" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="514" y1="324" x2="534" y2="324" class="rail"/>
 <polygon points="521,321 527,324 521,327" class="arrow"/>
-<g id="1278370603">
+<g id="1249587494">
 <rect x="534" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="554" y="328" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="575" y1="324" x2="595" y2="324" class="rail"/>
 <polygon points="582,321 588,324 582,327" class="arrow"/>
-<g id="1880258091">
+<g id="1841635555">
 <rect x="595" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="615" y="328" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -5970,51 +5970,51 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceNestedExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="920397781">
-<g id="467125220">
-<g id="2026056669">
+<g id="781534635">
+<g id="1880115448">
+<g id="443816028">
 <rect x="56" y="44" width="153" height="28" class="nonterminal-box"/>
 <text x="132" y="62" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="209" y1="58" x2="229" y2="58" class="rail"/>
 <polygon points="216,55 222,58 216,61" class="arrow"/>
-<g id="453228992">
+<g id="1592979913">
 <rect x="229" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="249" y="62" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="270" y1="58" x2="290" y2="58" class="rail"/>
 <polygon points="277,55 283,58 277,61" class="arrow"/>
-<g id="1336686599">
+<g id="555726412">
 <rect x="290" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="356" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="422" y1="58" x2="442" y2="58" class="rail"/>
 <polygon points="429,55 435,58 429,61" class="arrow"/>
-<g id="1375508670">
+<g id="125716372">
 <rect x="442" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="462" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="483" y1="58" x2="503" y2="58" class="rail"/>
 <polygon points="490,55 496,58 490,61" class="arrow"/>
-<g id="813751455">
+<g id="1039272415">
 <rect x="503" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="569" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="635" y1="58" x2="655" y2="58" class="rail"/>
 <polygon points="642,55 648,58 642,61" class="arrow"/>
-<g id="919318262">
+<g id="1959250705">
 <rect x="655" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="675" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="696" y1="58" x2="716" y2="58" class="rail"/>
 <polygon points="703,55 709,58 703,61" class="arrow"/>
-<g id="411685928">
+<g id="683064851">
 <rect x="716" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="782" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="848" y1="58" x2="868" y2="58" class="rail"/>
 <polygon points="855,55 861,58 855,61" class="arrow"/>
-<g id="763729647">
+<g id="1560350326">
 <rect x="868" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="888" y="62" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6023,38 +6023,38 @@
 <line x1="909" y1="58" x2="909" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="909" y1="58" x2="925" y2="58" class="rail"/>
-<g id="1856680297">
-<g id="1887466102">
+<g id="2098676375">
+<g id="986024616">
 <rect x="162" y="82" width="153" height="28" class="nonterminal-box"/>
 <text x="238" y="100" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="315" y1="96" x2="335" y2="96" class="rail"/>
 <polygon points="322,93 328,96 322,99" class="arrow"/>
-<g id="645841114">
+<g id="664731077">
 <rect x="335" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="100" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="376" y1="96" x2="396" y2="96" class="rail"/>
 <polygon points="383,93 389,96 383,99" class="arrow"/>
-<g id="667748372">
+<g id="1924736510">
 <rect x="396" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="462" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="528" y1="96" x2="548" y2="96" class="rail"/>
 <polygon points="535,93 541,96 535,99" class="arrow"/>
-<g id="35661802">
+<g id="10282201">
 <rect x="548" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="568" y="100" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="589" y1="96" x2="609" y2="96" class="rail"/>
 <polygon points="596,93 602,96 596,99" class="arrow"/>
-<g id="1900082714">
+<g id="379236008">
 <rect x="609" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="675" y="100" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="741" y1="96" x2="761" y2="96" class="rail"/>
 <polygon points="748,93 754,96 748,99" class="arrow"/>
-<g id="560500984">
+<g id="1186597227">
 <rect x="761" y="82" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="781" y="100" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6065,44 +6065,44 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M909,96 Q917,96 917,88" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="1761080451">
-<g id="1840698401">
+<g id="1266289973">
+<g id="449502144">
 <rect x="132" y="120" width="153" height="28" class="nonterminal-box"/>
 <text x="208" y="138" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="285" y1="134" x2="305" y2="134" class="rail"/>
 <polygon points="292,131 298,134 292,137" class="arrow"/>
-<g id="456134571">
+<g id="1508301279">
 <rect x="305" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="325" y="138" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="346" y1="134" x2="366" y2="134" class="rail"/>
 <polygon points="353,131 359,134 353,137" class="arrow"/>
-<g id="2126164837">
+<g id="1333879513">
 <rect x="366" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="432" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="498" y1="134" x2="518" y2="134" class="rail"/>
 <polygon points="505,131 511,134 505,137" class="arrow"/>
-<g id="1168139298">
+<g id="138777156">
 <rect x="518" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="538" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="559" y1="134" x2="579" y2="134" class="rail"/>
 <polygon points="566,131 572,134 566,137" class="arrow"/>
-<g id="510437227">
+<g id="1142770775">
 <rect x="579" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="599" y="138" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="620" y1="134" x2="640" y2="134" class="rail"/>
 <polygon points="627,131 633,134 627,137" class="arrow"/>
-<g id="96120410">
+<g id="735730986">
 <rect x="640" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="706" y="138" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="772" y1="134" x2="792" y2="134" class="rail"/>
 <polygon points="779,131 785,134 779,137" class="arrow"/>
-<g id="774902803">
+<g id="1862886690">
 <rect x="792" y="120" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="812" y="138" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6113,32 +6113,32 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M909,134 Q917,134 917,126" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="794180817">
-<g id="324747529">
+<g id="194748833">
+<g id="1697357817">
 <rect x="238" y="158" width="153" height="28" class="nonterminal-box"/>
 <text x="314" y="176" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="391" y1="172" x2="411" y2="172" class="rail"/>
 <polygon points="398,169 404,172 398,175" class="arrow"/>
-<g id="1128527174">
+<g id="484556155">
 <rect x="411" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="431" y="176" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="452" y1="172" x2="472" y2="172" class="rail"/>
 <polygon points="459,169 465,172 459,175" class="arrow"/>
-<g id="1845359025">
+<g id="954592176">
 <rect x="472" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="538" y="176" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="604" y1="172" x2="624" y2="172" class="rail"/>
 <polygon points="611,169 617,172 611,175" class="arrow"/>
-<g id="989418337">
+<g id="602757692">
 <rect x="624" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="644" y="176" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="665" y1="172" x2="685" y2="172" class="rail"/>
 <polygon points="672,169 678,172 672,175" class="arrow"/>
-<g id="1935875646">
+<g id="444653039">
 <rect x="685" y="158" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="705" y="176" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6149,44 +6149,44 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M909,172 Q917,172 917,164" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="664998549">
-<g id="757342451">
+<g id="762114897">
+<g id="473195273">
 <rect x="132" y="196" width="153" height="28" class="nonterminal-box"/>
 <text x="208" y="214" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="285" y1="210" x2="305" y2="210" class="rail"/>
 <polygon points="292,207 298,210 292,213" class="arrow"/>
-<g id="1563823213">
+<g id="1430386185">
 <rect x="305" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="325" y="214" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="346" y1="210" x2="366" y2="210" class="rail"/>
 <polygon points="353,207 359,210 353,213" class="arrow"/>
-<g id="919563035">
+<g id="1236412139">
 <rect x="366" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="386" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="407" y1="210" x2="427" y2="210" class="rail"/>
 <polygon points="414,207 420,210 414,213" class="arrow"/>
-<g id="677476775">
+<g id="527569109">
 <rect x="427" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="493" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="559" y1="210" x2="579" y2="210" class="rail"/>
 <polygon points="566,207 572,210 566,213" class="arrow"/>
-<g id="617543648">
+<g id="543233049">
 <rect x="579" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="599" y="214" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="620" y1="210" x2="640" y2="210" class="rail"/>
 <polygon points="627,207 633,210 627,213" class="arrow"/>
-<g id="1240908400">
+<g id="2051694498">
 <rect x="640" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="706" y="214" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="772" y1="210" x2="792" y2="210" class="rail"/>
 <polygon points="779,207 785,210 779,213" class="arrow"/>
-<g id="78442470">
+<g id="571980670">
 <rect x="792" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="812" y="214" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6197,32 +6197,32 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M909,210 Q917,210 917,202" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="2111718832">
-<g id="1954648182">
+<g id="805257874">
+<g id="92666681">
 <rect x="238" y="234" width="153" height="28" class="nonterminal-box"/>
 <text x="314" y="252" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="391" y1="248" x2="411" y2="248" class="rail"/>
 <polygon points="398,245 404,248 398,251" class="arrow"/>
-<g id="194722260">
+<g id="765072228">
 <rect x="411" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="431" y="252" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="452" y1="248" x2="472" y2="248" class="rail"/>
 <polygon points="459,245 465,248 459,251" class="arrow"/>
-<g id="1756046494">
+<g id="852070882">
 <rect x="472" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="492" y="252" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="513" y1="248" x2="533" y2="248" class="rail"/>
 <polygon points="520,245 526,248 520,251" class="arrow"/>
-<g id="1470342308">
+<g id="2029324945">
 <rect x="533" y="234" width="132" height="28" class="nonterminal-box"/>
 <text x="599" y="252" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="665" y1="248" x2="685" y2="248" class="rail"/>
 <polygon points="672,245 678,248 672,251" class="arrow"/>
-<g id="802786310">
+<g id="1375955589">
 <rect x="685" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="705" y="252" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6233,38 +6233,38 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M909,248 Q917,248 917,240" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="359582609">
-<g id="1281364289">
+<g id="1228145336">
+<g id="1363640334">
 <rect x="208" y="272" width="153" height="28" class="nonterminal-box"/>
 <text x="284" y="290" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="361" y1="286" x2="381" y2="286" class="rail"/>
 <polygon points="368,283 374,286 368,289" class="arrow"/>
-<g id="111942381">
+<g id="20363573">
 <rect x="381" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="401" y="290" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="422" y1="286" x2="442" y2="286" class="rail"/>
 <polygon points="429,283 435,286 429,289" class="arrow"/>
-<g id="1710628738">
+<g id="1219013844">
 <rect x="442" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="462" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="483" y1="286" x2="503" y2="286" class="rail"/>
 <polygon points="490,283 496,286 490,289" class="arrow"/>
-<g id="1787442505">
+<g id="496405633">
 <rect x="503" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="523" y="290" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="544" y1="286" x2="564" y2="286" class="rail"/>
 <polygon points="551,283 557,286 551,289" class="arrow"/>
-<g id="640469824">
+<g id="1882994893">
 <rect x="564" y="272" width="132" height="28" class="nonterminal-box"/>
 <text x="630" y="290" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="696" y1="286" x2="716" y2="286" class="rail"/>
 <polygon points="703,283 709,286 703,289" class="arrow"/>
-<g id="1077003802">
+<g id="1148700910">
 <rect x="716" y="272" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="736" y="290" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6275,26 +6275,26 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M909,286 Q917,286 917,278" class="rail" fill="none"/>
 <path d="M917,66 Q917,58 925,58" class="rail" fill="none"/>
-<g id="1099582189">
-<g id="779457544">
+<g id="2032014608">
+<g id="1617915291">
 <rect x="314" y="310" width="153" height="28" class="nonterminal-box"/>
 <text x="390" y="328" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
 <line x1="467" y1="324" x2="487" y2="324" class="rail"/>
 <polygon points="474,321 480,324 474,327" class="arrow"/>
-<g id="1849896013">
+<g id="1904528139">
 <rect x="487" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="507" y="328" text-anchor="middle" class="terminal-text">'['</text>
 </g>
 <line x1="528" y1="324" x2="548" y2="324" class="rail"/>
 <polygon points="535,321 541,324 535,327" class="arrow"/>
-<g id="546059913">
+<g id="189681005">
 <rect x="548" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="568" y="328" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="589" y1="324" x2="609" y2="324" class="rail"/>
 <polygon points="596,321 602,324 596,327" class="arrow"/>
-<g id="1138578250">
+<g id="1644609406">
 <rect x="609" y="310" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="629" y="328" text-anchor="middle" class="terminal-text">']'</text>
 </g>
@@ -6330,8 +6330,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">SliceExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1300617554">
-<g id="1998940153">
+<g id="165469024">
+<g id="1464422449">
 <rect x="56" y="44" width="167" height="28" class="nonterminal-box"/>
 <text x="139" y="62" text-anchor="middle" class="nonterminal-text">SliceNestedExpression</text>
 </g>
@@ -6339,7 +6339,7 @@
 <line x1="223" y1="58" x2="223" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="223" y1="58" x2="239" y2="58" class="rail"/>
-<g id="1581989204">
+<g id="6547689">
 <rect x="63" y="82" width="153" height="28" class="nonterminal-box"/>
 <text x="139" y="100" text-anchor="middle" class="nonterminal-text">SliceBaseExpression</text>
 </g>
@@ -6374,22 +6374,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1264837328">
-<g id="447786424">
+<g id="1426899475">
+<g id="224423917">
 <rect x="40" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="85" y="62" text-anchor="middle" class="nonterminal-text">StringTerm</text>
 </g>
 <line x1="130" y1="58" x2="150" y2="58" class="rail"/>
 <polygon points="137,55 143,58 137,61" class="arrow"/>
-<g id="1035900164">
-<g id="586953102">
-<g id="1182145464">
+<g id="1861693771">
+<g id="1617307053">
+<g id="280325800">
 <rect x="166" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="86" text-anchor="middle" class="terminal-text">'+'</text>
 </g>
 <line x1="207" y1="82" x2="227" y2="82" class="rail"/>
 <polygon points="214,79 220,82 214,85" class="arrow"/>
-<g id="1095778239">
+<g id="252639479">
 <rect x="227" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="272" y="86" text-anchor="middle" class="nonterminal-text">StringTerm</text>
 </g>
@@ -6433,20 +6433,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ParenthesizedStringExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1438846034">
-<g id="185500100">
+<g id="404888284">
+<g id="767381765">
 <rect x="40" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="81" y1="58" x2="101" y2="58" class="rail"/>
 <polygon points="88,55 94,58 88,61" class="arrow"/>
-<g id="1211998570">
+<g id="2091336274">
 <rect x="101" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="233" y1="58" x2="253" y2="58" class="rail"/>
 <polygon points="240,55 246,58 240,61" class="arrow"/>
-<g id="31595484">
+<g id="730679780">
 <rect x="253" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="273" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -6475,8 +6475,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringTerm</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1997439788">
-<g id="708618127">
+<g id="238447434">
+<g id="1599100324">
 <rect x="84" y="44" width="167" height="28" class="nonterminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="nonterminal-text">StringMatchExpression</text>
 </g>
@@ -6484,7 +6484,7 @@
 <line x1="251" y1="58" x2="279" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="279" y1="58" x2="295" y2="58" class="rail"/>
-<g id="254768467">
+<g id="421738958">
 <rect x="56" y="82" width="223" height="28" class="nonterminal-box"/>
 <text x="167" y="100" text-anchor="middle" class="nonterminal-text">ParenthesizedStringExpression</text>
 </g>
@@ -6494,7 +6494,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M279,96 Q287,96 287,88" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="503489425">
+<g id="1478525287">
 <rect x="105" y="120" width="125" height="28" class="nonterminal-box"/>
 <text x="167" y="138" text-anchor="middle" class="nonterminal-text">SliceExpression</text>
 </g>
@@ -6504,7 +6504,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M279,134 Q287,134 287,126" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1408142751">
+<g id="1356629061">
 <rect x="73" y="158" width="188" height="28" class="nonterminal-box"/>
 <text x="167" y="176" text-anchor="middle" class="nonterminal-text">ExternalStringInvocation</text>
 </g>
@@ -6514,7 +6514,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M279,172 Q287,172 287,164" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="480331954">
+<g id="234620559">
 <rect x="91" y="196" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="214" text-anchor="middle" class="nonterminal-text">ToUpperCaseFunction</text>
 </g>
@@ -6524,7 +6524,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M279,210 Q287,210 287,202" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1758475160">
+<g id="227652535">
 <rect x="91" y="234" width="153" height="28" class="nonterminal-box"/>
 <text x="167" y="252" text-anchor="middle" class="nonterminal-text">ToLowerCaseFunction</text>
 </g>
@@ -6534,7 +6534,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M279,248 Q287,248 287,240" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1665469240">
+<g id="1374036187">
 <rect x="115" y="272" width="104" height="28" class="nonterminal-box"/>
 <text x="167" y="290" text-anchor="middle" class="nonterminal-text">TrimFunction</text>
 </g>
@@ -6544,7 +6544,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M279,286 Q287,286 287,278" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1147199674">
+<g id="1705801742">
 <rect x="87" y="310" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="328" text-anchor="middle" class="nonterminal-text">ToUpperCaseDotMethod</text>
 </g>
@@ -6554,7 +6554,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M279,324 Q287,324 287,316" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1376965724">
+<g id="134861386">
 <rect x="87" y="348" width="160" height="28" class="nonterminal-box"/>
 <text x="167" y="366" text-anchor="middle" class="nonterminal-text">ToLowerCaseDotMethod</text>
 </g>
@@ -6564,7 +6564,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M279,362 Q287,362 287,354" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1001877877">
+<g id="142984439">
 <rect x="112" y="386" width="111" height="28" class="nonterminal-box"/>
 <text x="167" y="404" text-anchor="middle" class="nonterminal-text">TrimDotMethod</text>
 </g>
@@ -6574,7 +6574,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M279,400 Q287,400 287,392" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="1885381104">
+<g id="1745214916">
 <rect x="136" y="424" width="62" height="28" class="nonterminal-box"/>
 <text x="167" y="442" text-anchor="middle" class="nonterminal-text">STRING</text>
 </g>
@@ -6584,7 +6584,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M279,438 Q287,438 287,430" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="860285558">
+<g id="1861203138">
 <rect x="119" y="462" width="97" height="28" class="nonterminal-box"/>
 <text x="167" y="480" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -6594,7 +6594,7 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M279,476 Q287,476 287,468" class="rail" fill="none"/>
 <path d="M287,66 Q287,58 295,58" class="rail" fill="none"/>
-<g id="2008184950">
+<g id="682799319">
 <rect x="101" y="500" width="132" height="28" class="nonterminal-box"/>
 <text x="167" y="518" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -6629,22 +6629,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1868569813">
-<g id="43303708">
+<g id="530858907">
+<g id="1218149557">
 <rect x="40" y="44" width="160" height="28" class="nonterminal-box"/>
 <text x="120" y="62" text-anchor="middle" class="nonterminal-text">BooleanAndExpression</text>
 </g>
 <line x1="200" y1="58" x2="220" y2="58" class="rail"/>
 <polygon points="207,55 213,58 207,61" class="arrow"/>
-<g id="1168932494">
-<g id="1627708817">
-<g id="101031010">
+<g id="1223972317">
+<g id="1528423647">
+<g id="1531025600">
 <rect x="236" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="256" y="86" text-anchor="middle" class="terminal-text">'|'</text>
 </g>
 <line x1="277" y1="82" x2="297" y2="82" class="rail"/>
 <polygon points="284,79 290,82 284,85" class="arrow"/>
-<g id="1645225244">
+<g id="1724432247">
 <rect x="297" y="68" width="160" height="28" class="nonterminal-box"/>
 <text x="377" y="86" text-anchor="middle" class="nonterminal-text">BooleanAndExpression</text>
 </g>
@@ -6688,22 +6688,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanAndExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="947180427">
-<g id="213642464">
+<g id="854499140">
+<g id="1018455071">
 <rect x="40" y="44" width="160" height="28" class="nonterminal-box"/>
 <text x="120" y="62" text-anchor="middle" class="nonterminal-text">BooleanXorExpression</text>
 </g>
 <line x1="200" y1="58" x2="220" y2="58" class="rail"/>
 <polygon points="207,55 213,58 207,61" class="arrow"/>
-<g id="1359741121">
-<g id="42147997">
-<g id="1259618483">
+<g id="1621204506">
+<g id="2133494140">
+<g id="681529418">
 <rect x="236" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="256" y="86" text-anchor="middle" class="terminal-text">'&amp;'</text>
 </g>
 <line x1="277" y1="82" x2="297" y2="82" class="rail"/>
 <polygon points="284,79 290,82 284,85" class="arrow"/>
-<g id="1835667281">
+<g id="1110417977">
 <rect x="297" y="68" width="160" height="28" class="nonterminal-box"/>
 <text x="377" y="86" text-anchor="middle" class="nonterminal-text">BooleanXorExpression</text>
 </g>
@@ -6747,22 +6747,22 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanXorExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1217539683">
-<g id="98128723">
+<g id="2008427861">
+<g id="233823562">
 <rect x="40" y="44" width="111" height="28" class="nonterminal-box"/>
 <text x="95" y="62" text-anchor="middle" class="nonterminal-text">BooleanFactor</text>
 </g>
 <line x1="151" y1="58" x2="171" y2="58" class="rail"/>
 <polygon points="158,55 164,58 158,61" class="arrow"/>
-<g id="2114250218">
-<g id="831023939">
-<g id="516234429">
+<g id="2143085716">
+<g id="206204378">
+<g id="640009442">
 <rect x="187" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="207" y="86" text-anchor="middle" class="terminal-text">'^'</text>
 </g>
 <line x1="228" y1="82" x2="248" y2="82" class="rail"/>
 <polygon points="235,79 241,82 235,85" class="arrow"/>
-<g id="796790188">
+<g id="1251532658">
 <rect x="248" y="68" width="111" height="28" class="nonterminal-box"/>
 <text x="303" y="86" text-anchor="middle" class="nonterminal-text">BooleanFactor</text>
 </g>
@@ -6806,26 +6806,26 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NotExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="12775056">
-<g id="392059312">
+<g id="1236191924">
+<g id="2077826974">
 <rect x="40" y="44" width="55" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="67" y="62" text-anchor="middle" class="terminal-text">'not'</text>
 </g>
 <line x1="95" y1="58" x2="115" y2="58" class="rail"/>
 <polygon points="102,55 108,58 102,61" class="arrow"/>
-<g id="1711204971">
+<g id="614635906">
 <rect x="115" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="135" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="156" y1="58" x2="176" y2="58" class="rail"/>
 <polygon points="163,55 169,58 163,61" class="arrow"/>
-<g id="1007446155">
+<g id="1008882118">
 <rect x="176" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="245" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="315" y1="58" x2="335" y2="58" class="rail"/>
 <polygon points="322,55 328,58 322,61" class="arrow"/>
-<g id="1697953887">
+<g id="2058887058">
 <rect x="335" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="355" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -6854,8 +6854,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanComparable</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1009091259">
-<g id="310239569">
+<g id="433034875">
+<g id="2037396618">
 <rect x="131" y="44" width="111" height="28" class="nonterminal-box"/>
 <text x="186" y="62" text-anchor="middle" class="nonterminal-text">NotExpression</text>
 </g>
@@ -6863,7 +6863,7 @@
 <line x1="242" y1="58" x2="317" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="317" y1="58" x2="333" y2="58" class="rail"/>
-<g id="1298828197">
+<g id="1467151875">
 <rect x="99" y="82" width="174" height="28" class="nonterminal-box"/>
 <text x="186" y="100" text-anchor="middle" class="nonterminal-text">BooleanMatchExpression</text>
 </g>
@@ -6873,7 +6873,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M317,96 Q325,96 325,88" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="232530967">
+<g id="1829513200">
 <rect x="89" y="120" width="195" height="28" class="nonterminal-box"/>
 <text x="186" y="138" text-anchor="middle" class="nonterminal-text">ExternalBooleanInvocation</text>
 </g>
@@ -6883,7 +6883,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M317,134 Q325,134 325,126" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="452848978">
+<g id="1380494223">
 <rect x="148" y="158" width="76" height="28" class="nonterminal-box"/>
 <text x="186" y="176" text-anchor="middle" class="nonterminal-text">InMethod</text>
 </g>
@@ -6893,7 +6893,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M317,172 Q325,172 325,164" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1744302133">
+<g id="711201064">
 <rect x="110" y="196" width="153" height="28" class="nonterminal-box"/>
 <text x="186" y="214" text-anchor="middle" class="nonterminal-text">StartsWithDotMethod</text>
 </g>
@@ -6903,7 +6903,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M317,210 Q325,210 325,202" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="2119788749">
+<g id="1793468553">
 <rect x="117" y="234" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="252" text-anchor="middle" class="nonterminal-text">EndsWithDotMethod</text>
 </g>
@@ -6913,7 +6913,7 @@
 <path d="M48,240 Q48,248 56,248" class="rail" fill="none"/>
 <path d="M317,248 Q325,248 325,240" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="315168653">
+<g id="1717150082">
 <rect x="117" y="272" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="290" text-anchor="middle" class="nonterminal-text">ContainsDotMethod</text>
 </g>
@@ -6923,7 +6923,7 @@
 <path d="M48,278 Q48,286 56,286" class="rail" fill="none"/>
 <path d="M317,286 Q325,286 325,278" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1739321339">
+<g id="1901750805">
 <rect x="113" y="310" width="146" height="28" class="nonterminal-box"/>
 <text x="186" y="328" text-anchor="middle" class="nonterminal-text">StartsWithFunction</text>
 </g>
@@ -6933,7 +6933,7 @@
 <path d="M48,316 Q48,324 56,324" class="rail" fill="none"/>
 <path d="M317,324 Q325,324 325,316" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1057344867">
+<g id="2067650631">
 <rect x="120" y="348" width="132" height="28" class="nonterminal-box"/>
 <text x="186" y="366" text-anchor="middle" class="nonterminal-text">EndsWithFunction</text>
 </g>
@@ -6943,7 +6943,7 @@
 <path d="M48,354 Q48,362 56,362" class="rail" fill="none"/>
 <path d="M317,362 Q325,362 325,354" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="170902862">
+<g id="541328841">
 <rect x="120" y="386" width="132" height="28" class="nonterminal-box"/>
 <text x="186" y="404" text-anchor="middle" class="nonterminal-text">ContainsFunction</text>
 </g>
@@ -6953,7 +6953,7 @@
 <path d="M48,392 Q48,400 56,400" class="rail" fill="none"/>
 <path d="M317,400 Q325,400 325,392" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1350622969">
+<g id="196797938">
 <rect x="117" y="424" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="442" text-anchor="middle" class="nonterminal-text">IsPresentFunction</text>
 </g>
@@ -6963,7 +6963,7 @@
 <path d="M48,430 Q48,438 56,438" class="rail" fill="none"/>
 <path d="M317,438 Q325,438 325,430" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1751922469">
+<g id="689060946">
 <rect x="110" y="462" width="153" height="28" class="nonterminal-box"/>
 <text x="186" y="480" text-anchor="middle" class="nonterminal-text">InTimeRangeFunction</text>
 </g>
@@ -6973,7 +6973,7 @@
 <path d="M48,468 Q48,476 56,476" class="rail" fill="none"/>
 <path d="M317,476 Q325,476 325,468" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="2039710110">
+<g id="1022895831">
 <rect x="99" y="500" width="174" height="28" class="nonterminal-box"/>
 <text x="186" y="518" text-anchor="middle" class="nonterminal-text">InDayTimeRangeFunction</text>
 </g>
@@ -6983,7 +6983,7 @@
 <path d="M48,506 Q48,514 56,514" class="rail" fill="none"/>
 <path d="M317,514 Q325,514 325,506" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="224538199">
+<g id="1016202956">
 <rect x="155" y="538" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="556" text-anchor="middle" class="terminal-text">'true'</text>
 </g>
@@ -6993,7 +6993,7 @@
 <path d="M48,544 Q48,552 56,552" class="rail" fill="none"/>
 <path d="M317,552 Q325,552 325,544" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1531137556">
+<g id="1616634329">
 <rect x="152" y="576" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="186" y="594" text-anchor="middle" class="terminal-text">'false'</text>
 </g>
@@ -7003,7 +7003,7 @@
 <path d="M48,582 Q48,590 56,590" class="rail" fill="none"/>
 <path d="M317,590 Q325,590 325,582" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1386188614">
+<g id="1477685548">
 <rect x="138" y="614" width="97" height="28" class="nonterminal-box"/>
 <text x="186" y="632" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -7013,7 +7013,7 @@
 <path d="M48,620 Q48,628 56,628" class="rail" fill="none"/>
 <path d="M317,628 Q325,628 325,620" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="929393658">
+<g id="622918247">
 <rect x="120" y="652" width="132" height="28" class="nonterminal-box"/>
 <text x="186" y="670" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -7023,20 +7023,20 @@
 <path d="M48,658 Q48,666 56,666" class="rail" fill="none"/>
 <path d="M317,666 Q325,666 325,658" class="rail" fill="none"/>
 <path d="M325,66 Q325,58 333,58" class="rail" fill="none"/>
-<g id="1484193073">
-<g id="728361943">
+<g id="1372332895">
+<g id="153631849">
 <rect x="56" y="690" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="708" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="97" y1="704" x2="117" y2="704" class="rail"/>
 <polygon points="104,701 110,704 104,707" class="arrow"/>
-<g id="1780167488">
+<g id="918704572">
 <rect x="117" y="690" width="139" height="28" class="nonterminal-box"/>
 <text x="186" y="708" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="256" y1="704" x2="276" y2="704" class="rail"/>
 <polygon points="263,701 269,704 263,707" class="arrow"/>
-<g id="1146119418">
+<g id="1931287705">
 <rect x="276" y="690" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="296" y="708" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -7072,20 +7072,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanEqualityExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="930572475">
-<g id="253175628">
+<g id="1941534747">
+<g id="1034189647">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="1210574304">
+<g id="650527158">
 <rect x="199" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="244" y="62" text-anchor="middle" class="nonterminal-text">EqualityOp</text>
 </g>
 <line x1="289" y1="58" x2="309" y2="58" class="rail"/>
 <polygon points="296,55 302,58 296,61" class="arrow"/>
-<g id="668403360">
+<g id="371214570">
 <rect x="309" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="378" y="62" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
 </g>
@@ -7114,8 +7114,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanFactor</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="83835428">
-<g id="32248926">
+<g id="1888557446">
+<g id="1834556192">
 <rect x="59" y="44" width="195" height="28" class="nonterminal-box"/>
 <text x="156" y="62" text-anchor="middle" class="nonterminal-text">BooleanEqualityExpression</text>
 </g>
@@ -7123,17 +7123,17 @@
 <line x1="254" y1="58" x2="258" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="258" y1="58" x2="274" y2="58" class="rail"/>
-<g id="1989409126">
-<rect x="87" y="82" width="139" height="28" class="nonterminal-box"/>
-<text x="156" y="100" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
+<g id="2038836428">
+<rect x="77" y="82" width="160" height="28" class="nonterminal-box"/>
+<text x="157" y="100" text-anchor="middle" class="nonterminal-text">ComparisonExpression</text>
 </g>
-<line x1="56" y1="96" x2="87" y2="96" class="rail"/>
-<line x1="226" y1="96" x2="258" y2="96" class="rail"/>
+<line x1="56" y1="96" x2="77" y2="96" class="rail"/>
+<line x1="237" y1="96" x2="258" y2="96" class="rail"/>
 <path d="M40,58 Q48,58 48,66" class="rail" fill="none"/>
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M258,96 Q266,96 266,88" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="1777210130">
+<g id="1844796430">
 <rect x="56" y="120" width="202" height="28" class="nonterminal-box"/>
 <text x="157" y="138" text-anchor="middle" class="nonterminal-text">StringComparisonExpression</text>
 </g>
@@ -7143,12 +7143,12 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M258,134 Q266,134 266,126" class="rail" fill="none"/>
 <path d="M266,66 Q266,58 274,58" class="rail" fill="none"/>
-<g id="1708166180">
-<rect x="77" y="158" width="160" height="28" class="nonterminal-box"/>
-<text x="157" y="176" text-anchor="middle" class="nonterminal-text">ComparisonExpression</text>
+<g id="1437894667">
+<rect x="87" y="158" width="139" height="28" class="nonterminal-box"/>
+<text x="156" y="176" text-anchor="middle" class="nonterminal-text">BooleanComparable</text>
 </g>
-<line x1="56" y1="172" x2="77" y2="172" class="rail"/>
-<line x1="237" y1="172" x2="258" y2="172" class="rail"/>
+<line x1="56" y1="172" x2="87" y2="172" class="rail"/>
+<line x1="226" y1="172" x2="258" y2="172" class="rail"/>
 <path d="M40,58 Q48,58 48,66" class="rail" fill="none"/>
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M258,172 Q266,172 266,164" class="rail" fill="none"/>
@@ -7178,20 +7178,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringComparisonExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1747084960">
-<g id="1833876244">
+<g id="1993067365">
+<g id="943303444">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="1956725548">
+<g id="2146141489">
 <rect x="192" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="237" y="62" text-anchor="middle" class="nonterminal-text">EqualityOp</text>
 </g>
 <line x1="282" y1="58" x2="302" y2="58" class="rail"/>
 <polygon points="289,55 295,58 289,61" class="arrow"/>
-<g id="359743536">
+<g id="250523159">
 <rect x="302" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="368" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -7220,8 +7220,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">EqualityOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="293978780">
-<g id="1890383531">
+<g id="1532755170">
+<g id="64995235">
 <rect x="56" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="62" text-anchor="middle" class="terminal-text">'=='</text>
 </g>
@@ -7229,7 +7229,7 @@
 <line x1="104" y1="58" x2="104" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="104" y1="58" x2="120" y2="58" class="rail"/>
-<g id="250246065">
+<g id="540958948">
 <rect x="56" y="82" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="100" text-anchor="middle" class="terminal-text">'!='</text>
 </g>
@@ -7264,20 +7264,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ComparisonExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="526593907">
-<g id="1785311594">
+<g id="1517108384">
+<g id="1935901711">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
 <line x1="172" y1="58" x2="192" y2="58" class="rail"/>
 <polygon points="179,55 185,58 179,61" class="arrow"/>
-<g id="2112297762">
+<g id="222240615">
 <rect x="192" y="44" width="83" height="28" class="nonterminal-box"/>
 <text x="233" y="62" text-anchor="middle" class="nonterminal-text">CompareOp</text>
 </g>
 <line x1="275" y1="58" x2="295" y2="58" class="rail"/>
 <polygon points="282,55 288,58 282,61" class="arrow"/>
-<g id="550344916">
+<g id="1582659428">
 <rect x="295" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="361" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -7306,8 +7306,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">CompareOp</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1266904085">
-<g id="942026516">
+<g id="391267417">
+<g id="901875742">
 <rect x="56" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="62" text-anchor="middle" class="terminal-text">'=='</text>
 </g>
@@ -7315,7 +7315,7 @@
 <line x1="104" y1="58" x2="104" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="104" y1="58" x2="120" y2="58" class="rail"/>
-<g id="2103250233">
+<g id="1081114086">
 <rect x="56" y="82" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="100" text-anchor="middle" class="terminal-text">'!='</text>
 </g>
@@ -7325,7 +7325,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M104,96 Q112,96 112,88" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="823796094">
+<g id="904649947">
 <rect x="56" y="120" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="138" text-anchor="middle" class="terminal-text">'&lt;='</text>
 </g>
@@ -7335,7 +7335,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M104,134 Q112,134 112,126" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="923048089">
+<g id="105938682">
 <rect x="56" y="158" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="80" y="176" text-anchor="middle" class="terminal-text">'&gt;='</text>
 </g>
@@ -7345,7 +7345,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M104,172 Q112,172 112,164" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="1054040034">
+<g id="1063819094">
 <rect x="59" y="196" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="79" y="214" text-anchor="middle" class="terminal-text">'&lt;'</text>
 </g>
@@ -7355,7 +7355,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M104,210 Q112,210 112,202" class="rail" fill="none"/>
 <path d="M112,66 Q112,58 120,58" class="rail" fill="none"/>
-<g id="737323460">
+<g id="2092188176">
 <rect x="59" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="79" y="252" text-anchor="middle" class="terminal-text">'&gt;'</text>
 </g>
@@ -7390,8 +7390,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">ObjectExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1655749630">
-<g id="1490089388">
+<g id="803292439">
+<g id="317743079">
 <rect x="84" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="150" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -7399,7 +7399,7 @@
 <line x1="216" y1="58" x2="244" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="244" y1="58" x2="260" y2="58" class="rail"/>
-<g id="2086178075">
+<g id="1767487688">
 <rect x="84" y="82" width="132" height="28" class="nonterminal-box"/>
 <text x="150" y="100" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -7409,7 +7409,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M244,96 Q252,96 252,88" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1113241565">
+<g id="925090609">
 <rect x="80" y="120" width="139" height="28" class="nonterminal-box"/>
 <text x="149" y="138" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
@@ -7419,7 +7419,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M244,134 Q252,134 252,126" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="317294663">
+<g id="844511488">
 <rect x="56" y="158" width="188" height="28" class="nonterminal-box"/>
 <text x="150" y="176" text-anchor="middle" class="nonterminal-text">ExternalObjectInvocation</text>
 </g>
@@ -7429,7 +7429,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M244,172 Q252,172 252,164" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1305178659">
+<g id="575231946">
 <rect x="101" y="196" width="97" height="28" class="nonterminal-box"/>
 <text x="149" y="214" text-anchor="middle" class="nonterminal-text">VariableRef</text>
 </g>
@@ -7439,7 +7439,7 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M244,210 Q252,210 252,202" class="rail" fill="none"/>
 <path d="M252,66 Q252,58 260,58" class="rail" fill="none"/>
-<g id="1967328980">
+<g id="116536499">
 <rect x="84" y="234" width="132" height="28" class="nonterminal-box"/>
 <text x="150" y="252" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -7474,68 +7474,68 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">IfExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="412310187">
-<g id="1019587679">
+<g id="1919627750">
+<g id="754771922">
 <rect x="40" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="64" y="62" text-anchor="middle" class="terminal-text">'if'</text>
 </g>
 <line x1="88" y1="58" x2="108" y2="58" class="rail"/>
 <polygon points="95,55 101,58 95,61" class="arrow"/>
-<g id="705268622">
+<g id="1147339392">
 <rect x="108" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="128" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="149" y1="58" x2="169" y2="58" class="rail"/>
 <polygon points="156,55 162,58 156,61" class="arrow"/>
-<g id="1196496309">
+<g id="1403248915">
 <rect x="169" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="238" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="308" y1="58" x2="328" y2="58" class="rail"/>
 <polygon points="315,55 321,58 315,61" class="arrow"/>
-<g id="551107050">
+<g id="1984946061">
 <rect x="328" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="348" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
 <line x1="369" y1="58" x2="389" y2="58" class="rail"/>
 <polygon points="376,55 382,58 376,61" class="arrow"/>
-<g id="837803770">
+<g id="1036412129">
 <rect x="389" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="409" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="430" y1="58" x2="450" y2="58" class="rail"/>
 <polygon points="437,55 443,58 437,61" class="arrow"/>
-<g id="1474066098">
+<g id="1634539227">
 <rect x="450" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="495" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="540" y1="58" x2="560" y2="58" class="rail"/>
 <polygon points="547,55 553,58 547,61" class="arrow"/>
-<g id="418331969">
+<g id="764074140">
 <rect x="560" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="580" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
 <line x1="601" y1="58" x2="621" y2="58" class="rail"/>
 <polygon points="608,55 614,58 608,61" class="arrow"/>
-<g id="1905283551">
+<g id="624019735">
 <rect x="621" y="44" width="62" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="652" y="62" text-anchor="middle" class="terminal-text">'else'</text>
 </g>
 <line x1="683" y1="58" x2="703" y2="58" class="rail"/>
 <polygon points="690,55 696,58 690,61" class="arrow"/>
-<g id="1053251865">
+<g id="735989820">
 <rect x="703" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="723" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="744" y1="58" x2="764" y2="58" class="rail"/>
 <polygon points="751,55 757,58 751,61" class="arrow"/>
-<g id="169525653">
+<g id="579620946">
 <rect x="764" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="809" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="854" y1="58" x2="874" y2="58" class="rail"/>
 <polygon points="861,55 867,58 861,61" class="arrow"/>
-<g id="1811869858">
+<g id="1496916647">
 <rect x="874" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="894" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -7564,44 +7564,44 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">TernaryExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1909118389">
-<g id="471390001">
+<g id="850928097">
+<g id="728612903">
 <rect x="40" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="62" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="81" y1="58" x2="101" y2="58" class="rail"/>
 <polygon points="88,55 94,58 88,61" class="arrow"/>
-<g id="1087548238">
+<g id="1797463000">
 <rect x="101" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="170" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="240" y1="58" x2="260" y2="58" class="rail"/>
 <polygon points="247,55 253,58 247,61" class="arrow"/>
-<g id="1555376150">
+<g id="2065641473">
 <rect x="260" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="280" y="62" text-anchor="middle" class="terminal-text">'?'</text>
 </g>
 <line x1="301" y1="58" x2="321" y2="58" class="rail"/>
 <polygon points="308,55 314,58 308,61" class="arrow"/>
-<g id="1592882985">
+<g id="1347472005">
 <rect x="321" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="366" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="411" y1="58" x2="431" y2="58" class="rail"/>
 <polygon points="418,55 424,58 418,61" class="arrow"/>
-<g id="76190361">
+<g id="368661584">
 <rect x="431" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="451" y="62" text-anchor="middle" class="terminal-text">':'</text>
 </g>
 <line x1="472" y1="58" x2="492" y2="58" class="rail"/>
 <polygon points="479,55 485,58 479,61" class="arrow"/>
-<g id="1364705693">
+<g id="1727488236">
 <rect x="492" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="537" y="62" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="582" y1="58" x2="602" y2="58" class="rail"/>
 <polygon points="589,55 595,58 589,61" class="arrow"/>
-<g id="618112569">
+<g id="1684720395">
 <rect x="602" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="622" y="62" text-anchor="middle" class="terminal-text">')'</text>
 </g>
@@ -7630,34 +7630,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberMatchExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1818902616">
-<g id="562339663">
+<g id="1054845888">
+<g id="1841084466">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'match'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1311828427">
+<g id="814830953">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1464825946">
+<g id="43119331">
 <rect x="190" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="235" y="62" text-anchor="middle" class="nonterminal-text">NumberCase</text>
 </g>
 <line x1="280" y1="58" x2="300" y2="58" class="rail"/>
 <polygon points="287,55 293,58 287,61" class="arrow"/>
-<g id="283253884">
-<g id="1011039750">
-<g id="1880057979">
+<g id="1311501156">
+<g id="1134567193">
+<g id="1901423737">
 <rect x="316" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="336" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="357" y1="82" x2="377" y2="82" class="rail"/>
 <polygon points="364,79 370,82 364,85" class="arrow"/>
-<g id="1970601938">
+<g id="2032154441">
 <rect x="377" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="422" y="86" text-anchor="middle" class="nonterminal-text">NumberCase</text>
 </g>
@@ -7678,19 +7678,19 @@
 </g>
 <line x1="483" y1="58" x2="503" y2="58" class="rail"/>
 <polygon points="490,55 496,58 490,61" class="arrow"/>
-<g id="463856299">
+<g id="348614780">
 <rect x="503" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="523" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="544" y1="58" x2="564" y2="58" class="rail"/>
 <polygon points="551,55 557,58 551,61" class="arrow"/>
-<g id="1241318498">
+<g id="1814398930">
 <rect x="564" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="633" y="62" text-anchor="middle" class="nonterminal-text">NumberDefaultCase</text>
 </g>
 <line x1="703" y1="58" x2="723" y2="58" class="rail"/>
 <polygon points="710,55 716,58 710,61" class="arrow"/>
-<g id="1818992725">
+<g id="800986520">
 <rect x="723" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="743" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -7719,20 +7719,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1981749521">
-<g id="1492015044">
+<g id="1298174155">
+<g id="288651511">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="2031191727">
+<g id="1374643732">
 <rect x="199" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="223" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="1221195984">
+<g id="237153124">
 <rect x="267" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="329" y="62" text-anchor="middle" class="nonterminal-text">NumberCaseValue</text>
 </g>
@@ -7761,20 +7761,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberDefaultCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="543539301">
-<g id="1558519905">
+<g id="119108582">
+<g id="2141301328">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'default'</text>
 </g>
 <line x1="123" y1="58" x2="143" y2="58" class="rail"/>
 <polygon points="130,55 136,58 130,61" class="arrow"/>
-<g id="699724204">
+<g id="1431616630">
 <rect x="143" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="784106290">
+<g id="1320567859">
 <rect x="211" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="273" y="62" text-anchor="middle" class="nonterminal-text">NumberCaseValue</text>
 </g>
@@ -7803,7 +7803,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">NumberCaseValue</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1442187808">
+<g id="1972943487">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -7831,34 +7831,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringMatchExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="847892074">
-<g id="1531029667">
+<g id="1190668344">
+<g id="98508726">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'match'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="288228842">
+<g id="2033472738">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="524716354">
+<g id="905879137">
 <rect x="190" y="44" width="90" height="28" class="nonterminal-box"/>
 <text x="235" y="62" text-anchor="middle" class="nonterminal-text">StringCase</text>
 </g>
 <line x1="280" y1="58" x2="300" y2="58" class="rail"/>
 <polygon points="287,55 293,58 287,61" class="arrow"/>
-<g id="1720795547">
-<g id="1303830006">
-<g id="2047092608">
+<g id="1658735474">
+<g id="588436711">
+<g id="92639715">
 <rect x="316" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="336" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="357" y1="82" x2="377" y2="82" class="rail"/>
 <polygon points="364,79 370,82 364,85" class="arrow"/>
-<g id="752258259">
+<g id="2019171402">
 <rect x="377" y="68" width="90" height="28" class="nonterminal-box"/>
 <text x="422" y="86" text-anchor="middle" class="nonterminal-text">StringCase</text>
 </g>
@@ -7879,19 +7879,19 @@
 </g>
 <line x1="483" y1="58" x2="503" y2="58" class="rail"/>
 <polygon points="490,55 496,58 490,61" class="arrow"/>
-<g id="1030902510">
+<g id="1274926147">
 <rect x="503" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="523" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="544" y1="58" x2="564" y2="58" class="rail"/>
 <polygon points="551,55 557,58 551,61" class="arrow"/>
-<g id="626712967">
+<g id="1668102458">
 <rect x="564" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="633" y="62" text-anchor="middle" class="nonterminal-text">StringDefaultCase</text>
 </g>
 <line x1="703" y1="58" x2="723" y2="58" class="rail"/>
 <polygon points="710,55 716,58 710,61" class="arrow"/>
-<g id="1593364919">
+<g id="1450015836">
 <rect x="723" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="743" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -7920,20 +7920,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="185399334">
-<g id="490934263">
+<g id="1394653037">
+<g id="1669509992">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="1877443329">
+<g id="1772942027">
 <rect x="199" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="223" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="2005565987">
+<g id="1411316798">
 <rect x="267" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="329" y="62" text-anchor="middle" class="nonterminal-text">StringCaseValue</text>
 </g>
@@ -7962,20 +7962,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringDefaultCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="301995899">
-<g id="238379527">
+<g id="1592422561">
+<g id="625956754">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'default'</text>
 </g>
 <line x1="123" y1="58" x2="143" y2="58" class="rail"/>
 <polygon points="130,55 136,58 130,61" class="arrow"/>
-<g id="1561921355">
+<g id="737919834">
 <rect x="143" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="2116095313">
+<g id="136783127">
 <rect x="211" y="44" width="125" height="28" class="nonterminal-box"/>
 <text x="273" y="62" text-anchor="middle" class="nonterminal-text">StringCaseValue</text>
 </g>
@@ -8004,7 +8004,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">StringCaseValue</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="922774118">
+<g id="21389097">
 <rect x="40" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="106" y="62" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -8032,34 +8032,34 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanMatchExpression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="2032244528">
-<g id="582357138">
+<g id="612386003">
+<g id="1959968072">
 <rect x="40" y="44" width="69" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="74" y="62" text-anchor="middle" class="terminal-text">'match'</text>
 </g>
 <line x1="109" y1="58" x2="129" y2="58" class="rail"/>
 <polygon points="116,55 122,58 116,61" class="arrow"/>
-<g id="1410058768">
+<g id="1164718424">
 <rect x="129" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="149" y="62" text-anchor="middle" class="terminal-text">'{'</text>
 </g>
 <line x1="170" y1="58" x2="190" y2="58" class="rail"/>
 <polygon points="177,55 183,58 177,61" class="arrow"/>
-<g id="1185068069">
+<g id="1217277484">
 <rect x="190" y="44" width="97" height="28" class="nonterminal-box"/>
 <text x="238" y="62" text-anchor="middle" class="nonterminal-text">BooleanCase</text>
 </g>
 <line x1="287" y1="58" x2="307" y2="58" class="rail"/>
 <polygon points="294,55 300,58 294,61" class="arrow"/>
-<g id="971277870">
-<g id="1790186689">
-<g id="1925559757">
+<g id="123729813">
+<g id="1041842484">
+<g id="2072157955">
 <rect x="323" y="68" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="343" y="86" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="364" y1="82" x2="384" y2="82" class="rail"/>
 <polygon points="371,79 377,82 371,85" class="arrow"/>
-<g id="1625622919">
+<g id="450581958">
 <rect x="384" y="68" width="97" height="28" class="nonterminal-box"/>
 <text x="432" y="86" text-anchor="middle" class="nonterminal-text">BooleanCase</text>
 </g>
@@ -8080,19 +8080,19 @@
 </g>
 <line x1="497" y1="58" x2="517" y2="58" class="rail"/>
 <polygon points="504,55 510,58 504,61" class="arrow"/>
-<g id="1724921602">
+<g id="1749687034">
 <rect x="517" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="537" y="62" text-anchor="middle" class="terminal-text">','</text>
 </g>
 <line x1="558" y1="58" x2="578" y2="58" class="rail"/>
 <polygon points="565,55 571,58 565,61" class="arrow"/>
-<g id="775005038">
+<g id="687806288">
 <rect x="578" y="44" width="146" height="28" class="nonterminal-box"/>
 <text x="651" y="62" text-anchor="middle" class="nonterminal-text">BooleanDefaultCase</text>
 </g>
 <line x1="724" y1="58" x2="744" y2="58" class="rail"/>
 <polygon points="731,55 737,58 731,61" class="arrow"/>
-<g id="1693034613">
+<g id="1545331610">
 <rect x="744" y="44" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="764" y="62" text-anchor="middle" class="terminal-text">'}'</text>
 </g>
@@ -8121,20 +8121,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="1632177451">
-<g id="514770737">
+<g id="1765054694">
+<g id="480577395">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
 <line x1="179" y1="58" x2="199" y2="58" class="rail"/>
 <polygon points="186,55 192,58 186,61" class="arrow"/>
-<g id="1025981785">
+<g id="1278268960">
 <rect x="199" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="223" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="247" y1="58" x2="267" y2="58" class="rail"/>
 <polygon points="254,55 260,58 254,61" class="arrow"/>
-<g id="337936520">
+<g id="1328872207">
 <rect x="267" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="333" y="62" text-anchor="middle" class="nonterminal-text">BooleanCaseValue</text>
 </g>
@@ -8163,20 +8163,20 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanDefaultCase</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="342258642">
-<g id="162974076">
+<g id="854585787">
+<g id="1570673708">
 <rect x="40" y="44" width="83" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="81" y="62" text-anchor="middle" class="terminal-text">'default'</text>
 </g>
 <line x1="123" y1="58" x2="143" y2="58" class="rail"/>
 <polygon points="130,55 136,58 130,61" class="arrow"/>
-<g id="234873062">
+<g id="391497833">
 <rect x="143" y="44" width="48" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="167" y="62" text-anchor="middle" class="terminal-text">'-&gt;'</text>
 </g>
 <line x1="191" y1="58" x2="211" y2="58" class="rail"/>
 <polygon points="198,55 204,58 198,61" class="arrow"/>
-<g id="1039073553">
+<g id="2144445711">
 <rect x="211" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="277" y="62" text-anchor="middle" class="nonterminal-text">BooleanCaseValue</text>
 </g>
@@ -8205,7 +8205,7 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">BooleanCaseValue</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="732214539">
+<g id="460926014">
 <rect x="40" y="44" width="139" height="28" class="nonterminal-box"/>
 <text x="109" y="62" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
@@ -8233,21 +8233,21 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">VariableRef</text>
 <circle cx="24" cy="76" r="4" class="start-circle"/>
 <line x1="28" y1="76" x2="40" y2="76" class="rail"/>
-<g id="403712491">
-<g id="1504610377">
+<g id="1488221379">
+<g id="584497592">
 <rect x="40" y="62" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="60" y="80" text-anchor="middle" class="terminal-text">'$'</text>
 </g>
 <line x1="81" y1="76" x2="101" y2="76" class="rail"/>
 <polygon points="88,73 94,76 88,79" class="arrow"/>
-<g id="470609380">
+<g id="1356695856">
 <rect x="101" y="62" width="90" height="28" class="nonterminal-box"/>
 <text x="146" y="80" text-anchor="middle" class="nonterminal-text">IDENTIFIER</text>
 </g>
 <line x1="191" y1="76" x2="211" y2="76" class="rail"/>
 <polygon points="198,73 204,76 198,79" class="arrow"/>
-<g id="902890456">
-<g id="995358036">
+<g id="1337466869">
+<g id="494061753">
 <rect x="227" y="62" width="76" height="28" class="nonterminal-box"/>
 <text x="265" y="80" text-anchor="middle" class="nonterminal-text">TypeHint</text>
 </g>
@@ -8284,8 +8284,8 @@
 <text x="20" y="38" font-size="13" fill="#555" font-family="sans-serif">Expression</text>
 <circle cx="24" cy="58" r="4" class="start-circle"/>
 <line x1="28" y1="58" x2="40" y2="58" class="rail"/>
-<g id="443551978">
-<g id="1661502656">
+<g id="271948418">
+<g id="1688003308">
 <rect x="96" y="44" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="62" text-anchor="middle" class="nonterminal-text">NumberExpression</text>
 </g>
@@ -8293,7 +8293,7 @@
 <line x1="228" y1="58" x2="268" y2="58" class="rail"/>
 <line x1="40" y1="58" x2="56" y2="58" class="rail"/>
 <line x1="268" y1="58" x2="284" y2="58" class="rail"/>
-<g id="1205150880">
+<g id="1872808390">
 <rect x="92" y="82" width="139" height="28" class="nonterminal-box"/>
 <text x="161" y="100" text-anchor="middle" class="nonterminal-text">BooleanExpression</text>
 </g>
@@ -8303,7 +8303,7 @@
 <path d="M48,88 Q48,96 56,96" class="rail" fill="none"/>
 <path d="M268,96 Q276,96 276,88" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="2057773121">
+<g id="1617437808">
 <rect x="96" y="120" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="138" text-anchor="middle" class="nonterminal-text">StringExpression</text>
 </g>
@@ -8313,7 +8313,7 @@
 <path d="M48,126 Q48,134 56,134" class="rail" fill="none"/>
 <path d="M268,134 Q276,134 276,126" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="1667305871">
+<g id="461461202">
 <rect x="96" y="158" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="176" text-anchor="middle" class="nonterminal-text">ObjectExpression</text>
 </g>
@@ -8323,7 +8323,7 @@
 <path d="M48,164 Q48,172 56,172" class="rail" fill="none"/>
 <path d="M268,172 Q276,172 276,164" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="1147713447">
+<g id="403262668">
 <rect x="96" y="196" width="132" height="28" class="nonterminal-box"/>
 <text x="162" y="214" text-anchor="middle" class="nonterminal-text">MethodInvocation</text>
 </g>
@@ -8333,20 +8333,20 @@
 <path d="M48,202 Q48,210 56,210" class="rail" fill="none"/>
 <path d="M268,210 Q276,210 276,202" class="rail" fill="none"/>
 <path d="M276,66 Q276,58 284,58" class="rail" fill="none"/>
-<g id="54665271">
-<g id="712403886">
+<g id="327092679">
+<g id="1896761586">
 <rect x="56" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="76" y="252" text-anchor="middle" class="terminal-text">'('</text>
 </g>
 <line x1="97" y1="248" x2="117" y2="248" class="rail"/>
 <polygon points="104,245 110,248 104,251" class="arrow"/>
-<g id="1762718601">
+<g id="1348774151">
 <rect x="117" y="234" width="90" height="28" class="nonterminal-box"/>
 <text x="162" y="252" text-anchor="middle" class="nonterminal-text">Expression</text>
 </g>
 <line x1="207" y1="248" x2="227" y2="248" class="rail"/>
 <polygon points="214,245 220,248 214,251" class="arrow"/>
-<g id="43416141">
+<g id="1103254047">
 <rect x="227" y="234" width="41" height="28" rx="10" ry="10" class="terminal-box"/>
 <text x="247" y="252" text-anchor="middle" class="terminal-text">')'</text>
 </g>

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/GeneratedAstRuntimeProbe.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/GeneratedAstRuntimeProbe.java
@@ -1,10 +1,10 @@
 package org.unlaxer.tinyexpression.evaluator.ast;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.unlaxer.tinyexpression.evaluator.p4.P4StrictMatchTypingValidator;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST;
+import org.unlaxer.tinyexpression.p4.P4PreferredAstMapper;
 import org.unlaxer.tinyexpression.parser.TinyExpressionParserCapabilities;
 
 final class GeneratedAstRuntimeProbe {
@@ -99,21 +99,14 @@ final class GeneratedAstRuntimeProbe {
 
   private static Optional<Object> tryMapAstOnce(String source, ClassLoader classLoader, String preferredAstSimpleName) {
     try {
-      Class<?> mapperClass = Class.forName(
-          "org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4Mapper", false, classLoader);
-      Object ast;
-      if (preferredAstSimpleName == null || preferredAstSimpleName.isBlank()) {
-        Method parse = mapperClass.getMethod("parse", String.class);
-        ast = parse.invoke(null, source);
-      } else {
-        try {
-          Method parsePreferred = mapperClass.getMethod("parse", String.class, String.class);
-          ast = parsePreferred.invoke(null, source, preferredAstSimpleName);
-        } catch (NoSuchMethodException ignored) {
-          Method parse = mapperClass.getMethod("parse", String.class);
-          ast = parse.invoke(null, source);
-        }
-      }
+      // Verify that the generated mapper classes are available in the given classLoader
+      // before attempting to parse, preserving the optional-detection contract.
+      Class.forName("org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4Mapper", false, classLoader);
+      // Delegate to P4PreferredAstMapper.parseByAstSimpleName so that
+      // ScopeStore.registerDispatcher is called on the ParseContext before parsing,
+      // preventing "transaction nest is illegal" errors that occur when the dispatcher
+      // is absent from the generated TinyExpressionP4Mapper.parse method.
+      Object ast = P4PreferredAstMapper.parseByAstSimpleName(source, preferredAstSimpleName);
       if (ast != null
           && preferredAstSimpleName != null
           && !preferredAstSimpleName.isBlank()

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/BooleanBuilder.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/BooleanBuilder.java
@@ -10,6 +10,7 @@ import org.unlaxer.TypedToken;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.elementary.ParenthesesParser;
 import org.unlaxer.tinyexpression.evaluator.javacode.validator.ParserValuesValidator;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.BooleanExpression;
 import org.unlaxer.tinyexpression.parser.BooleanIfExpressionParser;
 import org.unlaxer.tinyexpression.parser.BooleanMatchExpressionParser;
@@ -50,6 +51,7 @@ public class BooleanBuilder implements TokenCodeBuilder {
   static {
     registerHandler(NotBooleanExpressionParser.class, BooleanBuilder::buildNotExpression);
     registerHandler(ParenthesesParser.class, BooleanBuilder::buildParenthesized);
+    registerHandler(JavaStyleParenthesesParser.class, BooleanBuilder::buildJavaStyleParenthesized);
     registerHandler(IsPresentParser.class, BooleanBuilder::buildIsPresent);
     registerHandler(InTimeRangeParser.class, BooleanBuilder::buildInTimeRange);
     registerHandler(InDayTimeRangeParser.class, BooleanBuilder::buildInDayTimeRange);
@@ -134,6 +136,14 @@ public class BooleanBuilder implements TokenCodeBuilder {
   private void buildParenthesized(SimpleJavaCodeBuilder builder, Token token,
       TinyExpressionTokens tinyExpressionTokens) {
     Token parenthesesed = ParenthesesParser.getParenthesesed(token);
+    builder.append("(");
+    BooleanExpressionBuilder.SINGLETON.build(builder, parenthesesed, tinyExpressionTokens);
+    builder.append(")");
+  }
+
+  private void buildJavaStyleParenthesized(SimpleJavaCodeBuilder builder, Token token,
+      TinyExpressionTokens tinyExpressionTokens) {
+    Token parenthesesed = ((JavaStyleParenthesesParser) token.parser).getInnerParserParsed(token);
     builder.append("(");
     BooleanExpressionBuilder.SINGLETON.build(builder, parenthesesed, tinyExpressionTokens);
     builder.append(")");

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/OperatorOperandTreeCreator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/OperatorOperandTreeCreator.java
@@ -111,6 +111,7 @@ import org.unlaxer.tinyexpression.parser.javalang.AnnotationParameterParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationsParser;
 import org.unlaxer.tinyexpression.parser.javalang.BooleanVariableDeclarationParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.javalang.NakedVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.NumberVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.StringVariableDeclarationParser;
@@ -417,13 +418,17 @@ public class OperatorOperandTreeCreator implements TokenReConstructorInterface{
       
       return operator;
       
-    }else if(parser instanceof StringVariableParser|| 
+    }else if(parser instanceof StringVariableParser||
         parser instanceof NakedVariableParser || parser instanceof ExclusiveNakedVariableParser){
-      
+
       return operator;
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
 
     }else if(parser instanceof TrimParser){
@@ -509,16 +514,20 @@ public class OperatorOperandTreeCreator implements TokenReConstructorInterface{
       );
       
     }else if(parser instanceof NumberMatchExpressionParser){
-      
+
       return operator.newCreatesOf(
         apply(NumberMatchExpressionParser.getCaseExpression(operator)),
         apply(NumberMatchExpressionParser.getDefaultExpression(operator))
       );
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof SinParser){
       
       return operator.newCreatesOf(apply(SinParser.getExpression(operator)));
@@ -702,10 +711,14 @@ public class OperatorOperandTreeCreator implements TokenReConstructorInterface{
       return operator;
       
       
+    }else if(parser instanceof JavaStyleParenthesesParser) {
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser) {
 
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof IsPresentParser) {
 
       return operator.newCreatesOf(IsPresentParser.getVariable(operator));

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/StringClauseBuilder.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/StringClauseBuilder.java
@@ -16,6 +16,7 @@ import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.combinator.ChoiceInterface;
 import org.unlaxer.parser.elementary.ParenthesesParser;
 import org.unlaxer.parser.elementary.QuotedParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.evaluator.javacode.SimpleJavaCodeBuilder.Kind;
 import org.unlaxer.tinyexpression.parser.ExpressionInterface;
 import org.unlaxer.tinyexpression.parser.IfExpressionParser;
@@ -60,6 +61,7 @@ public class StringClauseBuilder {
     registerHandler(NakedVariableParser.class, StringClauseBuilder::buildStringVariable);
     registerHandler(StringVariableParser.class, StringClauseBuilder::buildStringVariable);
     registerHandler(ParenthesesParser.class, StringClauseBuilder::buildParentheses);
+    registerHandler(JavaStyleParenthesesParser.class, StringClauseBuilder::buildParentheses);
     registerHandler(TrimParser.class, (self, token, tinyExpressionTokens) ->
         self.buildUnaryStringMethod(token, tinyExpressionTokens, ".trim()"));
     registerHandler(ToUpperCaseParser.class, (self, token, tinyExpressionTokens) ->

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/legacy/LegacyOperatorOperandTreeCreator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/legacy/LegacyOperatorOperandTreeCreator.java
@@ -109,6 +109,7 @@ import org.unlaxer.tinyexpression.parser.javalang.AnnotationParametersParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationParser;
 import org.unlaxer.tinyexpression.parser.javalang.AnnotationsParser;
 import org.unlaxer.tinyexpression.parser.javalang.BooleanVariableDeclarationParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.javalang.NakedVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.NumberVariableDeclarationParser;
 import org.unlaxer.tinyexpression.parser.javalang.StringVariableDeclarationParser;
@@ -406,13 +407,17 @@ public class LegacyOperatorOperandTreeCreator implements TokenReConstructorInter
       
       return operator;
       
-    }else if(parser instanceof StringVariableParser|| 
+    }else if(parser instanceof StringVariableParser||
         parser instanceof NakedVariableParser || parser instanceof ExclusiveNakedVariableParser){
-      
+
       return operator;
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
 
     }else if(parser instanceof TrimParser){
@@ -503,11 +508,15 @@ public class LegacyOperatorOperandTreeCreator implements TokenReConstructorInter
         apply(NumberMatchExpressionParser.getCaseExpression(operator)),
         apply(NumberMatchExpressionParser.getDefaultExpression(operator))
       );
-      
+
+    }else if(parser instanceof JavaStyleParenthesesParser){
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser){
-      
+
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof SinParser){
       
       return operator.newCreatesOf(apply(SinParser.getExpression(operator)));
@@ -691,10 +700,14 @@ public class LegacyOperatorOperandTreeCreator implements TokenReConstructorInter
       return operator;
       
       
+    }else if(parser instanceof JavaStyleParenthesesParser) {
+
+      return apply(((JavaStyleParenthesesParser)parser).getInnerParserParsed(operator));
+
     }else if(parser instanceof ParenthesesParser) {
 
       return apply(((ParenthesesParser)parser).getInnerParserParsed(operator));
-      
+
     }else if(parser instanceof IsPresentParser) {
 
       return operator.newCreatesOf(IsPresentParser.getVariable(operator));

--- a/src/main/java/org/unlaxer/tinyexpression/p4/P4PreferredAstMapper.java
+++ b/src/main/java/org/unlaxer/tinyexpression/p4/P4PreferredAstMapper.java
@@ -12,6 +12,7 @@ import org.unlaxer.Parsed;
 import org.unlaxer.StringSource;
 import org.unlaxer.Token;
 import org.unlaxer.context.ParseContext;
+import org.unlaxer.dsl.runtime.ScopeStore;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4Mapper;
@@ -81,6 +82,23 @@ public final class P4PreferredAstMapper {
 
   public static TinyExpressionP4AST parse(String formula, ExpressionType preferredResultType) {
     return parseDetailed(formula, preferredResultType).ast();
+  }
+
+  /**
+   * Parses {@code formula} requesting a specific AST node type by its simple class name.
+   * Unlike {@link #parse(String, ExpressionType)}, this method forwards the simple name
+   * directly to the underlying mapper so that it is honoured even when the result type is
+   * not known.  {@link ScopeStore#registerDispatcher(org.unlaxer.context.ParseContext)} is
+   * called on the {@link org.unlaxer.context.ParseContext} before parsing, preventing
+   * "transaction nest is illegal" errors that occur when the dispatcher is absent.
+   *
+   * @param formula               the expression source
+   * @param preferredAstSimpleName the simple class name of the desired AST node, or {@code null}
+   * @return the parsed AST
+   * @throws IllegalArgumentException if the formula cannot be parsed
+   */
+  public static TinyExpressionP4AST parseByAstSimpleName(String formula, String preferredAstSimpleName) {
+    return parseViaMapperCompat(formula != null ? formula : "", preferredAstSimpleName);
   }
 
   public static ParsedAst parseDetailed(String formula) {
@@ -893,6 +911,7 @@ public final class P4PreferredAstMapper {
 
   private static TinyExpressionP4AST parseViaMapperCompat(String source, String preferredAstSimpleName) {
     ParseContext context = new ParseContext(createRootSourceCompat(source));
+    ScopeStore.registerDispatcher(context);
     Parsed parsed;
     try {
       Parser rootParser = TinyExpressionP4Parsers.getRootParser();

--- a/src/main/java/org/unlaxer/tinyexpression/parser/AbstractBooleanFactorParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/AbstractBooleanFactorParser.java
@@ -8,7 +8,7 @@ import org.unlaxer.tinyexpression.parser.javatype.*;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.combinator.LazyChoice;
-import org.unlaxer.parser.elementary.ParenthesesParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 
 public abstract class AbstractBooleanFactorParser extends LazyChoice implements BooleanExpression , VariableTypeSelectable{
 
@@ -45,7 +45,7 @@ public abstract class AbstractBooleanFactorParser extends LazyChoice implements 
     parsers.add(BooleanIfExpressionParser.class);
     parsers.add(StrictTypedBooleanMatchExpressionParser.class);
     parsers.add(NotBooleanExpressionParser.class);
-    parsers.add(new ParenthesesParser(Parser.get(BooleanExpressionParser.class)));
+    parsers.add(new JavaStyleParenthesesParser(Parser.get(BooleanExpressionParser.class)));
     parsers.add(IsPresentParser.class);
     parsers.add(BooleanExpressionOfStringParser.class); // <- number == number系より早く評価しないとダメ
     parsers.add(NumberEqualEqualExpressionParser.class);

--- a/src/main/java/org/unlaxer/tinyexpression/parser/AbstractNumberFactorParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/AbstractNumberFactorParser.java
@@ -8,7 +8,7 @@ import org.unlaxer.tinyexpression.parser.javatype.*;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.combinator.LazyChoice;
-import org.unlaxer.parser.elementary.ParenthesesParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 import org.unlaxer.tinyexpression.parser.function.CosParser;
 import org.unlaxer.tinyexpression.parser.function.MaxParser;
 import org.unlaxer.tinyexpression.parser.function.MinParser;
@@ -57,7 +57,7 @@ public abstract class AbstractNumberFactorParser extends LazyChoice implements N
         NumberExpressionParser.class:
           StrictTypedNumberExpressionParser.class;
     
-    parsers.add(new ParenthesesParser(
+    parsers.add(new JavaStyleParenthesesParser(
         Parser.newInstance(
             expresionParserClazz)
         )

--- a/src/main/java/org/unlaxer/tinyexpression/parser/AbstractStringFactorParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/AbstractStringFactorParser.java
@@ -8,7 +8,7 @@ import org.unlaxer.tinyexpression.parser.javatype.*;
 import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.combinator.LazyChoice;
-import org.unlaxer.parser.elementary.ParenthesesParser;
+import org.unlaxer.tinyexpression.parser.javalang.JavaStyleParenthesesParser;
 
 public abstract class AbstractStringFactorParser extends LazyChoice implements StringExpression , VariableTypeSelectable{
 	
@@ -33,7 +33,7 @@ public abstract class AbstractStringFactorParser extends LazyChoice implements S
     if(withNakedVariable) {
       parsers.add(ExclusiveNakedVariableParser.class);
     }
-    parsers.add(new ParenthesesParser(Parser.get(NESTED)));
+    parsers.add(new JavaStyleParenthesesParser(Parser.get(NESTED)));
     parsers.add(TrimParser.class);
     parsers.add(ToUpperCaseParser.class);
     parsers.add(ToLowerCaseParser.class);

--- a/src/main/java/org/unlaxer/tinyexpression/parser/javalang/JavaStyleParenthesesParser.java
+++ b/src/main/java/org/unlaxer/tinyexpression/parser/javalang/JavaStyleParenthesesParser.java
@@ -6,7 +6,6 @@ import org.unlaxer.parser.Parser;
 import org.unlaxer.parser.Parsers;
 import org.unlaxer.parser.ascii.LeftParenthesisParser;
 import org.unlaxer.parser.ascii.RightParenthesisParser;
-import org.unlaxer.parser.elementary.ParenthesesParser;
 import org.unlaxer.util.annotation.TokenExtractor;
 
 public class JavaStyleParenthesesParser extends JavaStyleDelimitedLazyChain {
@@ -37,14 +36,14 @@ public class JavaStyleParenthesesParser extends JavaStyleDelimitedLazyChain {
   
   @TokenExtractor
   public static Token getParenthesesed(Token parenthesesed ){
-    if(false == parenthesesed.parser instanceof ParenthesesParser){
-      throw new IllegalArgumentException("this token did not generate from " + 
-        ParenthesesParser.class.getName());
+    if(false == parenthesesed.parser instanceof JavaStyleParenthesesParser){
+      throw new IllegalArgumentException("this token did not generate from " +
+        JavaStyleParenthesesParser.class.getName());
     }
-    Parser contentsParser = JavaStyleParenthesesParser.class.cast(parenthesesed.parser).inner;
+    Parser contentsParser = JavaStyleParenthesesParser.class.cast(parenthesesed.parser).getParenthesesedParser();
     return parenthesesed.getChildWithParser(parser -> parser.equals(contentsParser));
   }
-  
+
   public Parser getParenthesesedParser(){
     return inner == null ? Parser.get(clazz) : inner;
   }
@@ -62,7 +61,6 @@ public class JavaStyleParenthesesParser extends JavaStyleDelimitedLazyChain {
 
   @TokenExtractor
   public Token getInnerParserParsed(Token thisParserParsed) {
-//    return thisParserParsed.filteredChildren.get(1);
-    return thisParserParsed.getChildWithParser(parser->parser.equals(inner));
+    return thisParserParsed.getChildWithParser(parser->parser.equals(getParenthesesedParser()));
   }
 }

--- a/src/test/java/org/unlaxer/tinyexpression/parser/BooleanExpressionParserTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/parser/BooleanExpressionParserTest.java
@@ -13,14 +13,26 @@ public class BooleanExpressionParserTest extends ParserTestBase{
 
   @Test
   public void test() {
-    
+
     setLevel(OutputLevel.detail);
     BooleanExpressionParser parser = new BooleanExpressionParser();
-    
+
     testAllMatch(parser, "true");
     testAllMatch(parser, "true | false ");
     testAllMatch(parser, "true & $foo == 1");
     testAllMatch(parser, "$hour>0 & $hour<5");
+  }
+
+  @Test
+  public void testGroupingFollowedByComment() {
+    // Regression test for issue #14:
+    // comment after grouping like (a & b) // comment should not cause a parse error
+    BooleanExpressionParser parser = new BooleanExpressionParser();
+
+    testAllMatch(parser, "($foo == 1 & $bar == 2)");
+    testAllMatch(parser, "($foo == 1 & $bar == 2) // comment");
+    testAllMatch(parser, "($foo == 1 & $bar == 2) /* block comment */");
+    testAllMatch(parser, "($foo == 1) | ($bar == 2) // trailing comment");
   }
 
 }

--- a/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf
+++ b/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf
@@ -473,9 +473,9 @@ grammar TinyExpressionP4 {
   @mapping(BooleanFactorExpr, params=[value])
   BooleanFactor ::=
       BooleanEqualityExpression @value
-    | BooleanComparable @value
-    | StringComparisonExpression @value
     | ComparisonExpression @value
+    | StringComparisonExpression @value
+    | BooleanComparable @value
     ;
 
   // String equality: $var == 'text', 'a' != 'b', etc.


### PR DESCRIPTION
Closes #6

## Root Causes

Two bugs caused 32 `TernaryExpressionTest` errors and 11 `AstEvaluatorGeneratedValuePathTest` failures:

### 1. Grammar: `BooleanFactor` alternative ordering (primary cause)

`BooleanFactor` had `BooleanComparable` (which includes `VariableRef`) ordered **before** `ComparisonExpression`. When parsing a condition like `$a > 0`, the parser greedily matched `$a` as a `BooleanComparable`, leaving `> 0` unconsumed — making the `?` in the ternary unreachable.

Fix: swap ordering so `ComparisonExpression` is tried before `BooleanComparable` in `BooleanFactor`.

### 2. Missing `ScopeStore.registerDispatcher(context)` call

`P4PreferredAstMapper.parseViaMapperCompat` created a `ParseContext` without calling `ScopeStore.registerDispatcher(context)` before parsing. The grammar uses `@scopeTree(mode=lexical)`, `@backref`, and `@catalog` annotations that rely on the dispatcher; without it, these annotations trigger "transaction nest is illegal" errors on context close.

Fix: add `ScopeStore.registerDispatcher(context)` in `parseViaMapperCompat`. Also add a new `parseByAstSimpleName(String, String)` public method so that `GeneratedAstRuntimeProbe.tryMapAstOnce` delegates to `P4PreferredAstMapper` instead of calling the generated `TinyExpressionP4Mapper.parse` directly via reflection (which bypasses the dispatcher registration).

## Changes

- `tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf`: reorder `BooleanFactor` alternatives (`ComparisonExpression` before `BooleanComparable`)
- `src/main/java/.../p4/P4PreferredAstMapper.java`: add `ScopeStore.registerDispatcher(context)` + new `parseByAstSimpleName` method
- `src/main/java/.../evaluator/ast/GeneratedAstRuntimeProbe.java`: delegate to `P4PreferredAstMapper.parseByAstSimpleName` instead of reflection
- `docs/railroad/*.svg`: regenerated railroad diagrams from updated grammar

## Test plan

- [x] `TernaryExpressionTest` — all 32 cases pass (were ERROR)
- [x] `AstEvaluatorGeneratedValuePathTest` — all cases pass (were FAIL)
- [x] P4 smoke suite (`-P p4-smoke`) — 86 tests pass