### PR TITLE
perf(p4): AST キャッシュ + 文法網羅/パリティテスト + 不安定性調査

### DIFF
--- a/docs/findings-2026-06-15-unlaxer-3.0.4-and-p4.md
+++ b/docs/findings-2026-06-15-unlaxer-3.0.4-and-p4.md
@@ -1,0 +1,88 @@
+# P4 インタプリタ: 性能改善・網羅テスト・発見したバグ (2026-06-15)
+
+このブランチ (`p4-perf-and-tests`) は現 `master` の P4 実装の上に、(1) インタプリタの性能改善、
+(2) 文法由来の網羅テスト、(3) 発見した P4 バグの記録、を追加する。
+
+> 背景: master は既に P4 一次経路を稼働させている（`CodeBlock` のトークン直接インライン化、
+> `StringLiteralParser`、`BooleanComparable`/`BooleanEqualityExpression`、`InMethod` 等）。
+> 当初別ブランチで進めていた文法レベルの P4 復活作業は master に取り込み済みのため本ブランチには含めない。
+> 生成器側の改善 unlaxer-parser#41/#42 は unlaxer-parser リポジトリの別ブランチで扱う。
+
+## 1. 性能: AST キャッシュ（実装）
+
+`AstEvaluatorCalculator.apply()` は P4 一次経路で**毎回フルパース＋マップ**していた。巨大式では
+再パースが支配的（1評価あたり秒オーダー）。宣言を含まない式で typed 経路が成功した AST を
+インスタンスにキャッシュ (`cachedTypedAst`) し、以降の apply は再パースを省略して現在の
+`CalculationContext` で評価する（構造のみキャッシュ＝変数値は最新）。
+
+実測（`BackendSpeedBenchmarkTest`, @Ignore）:
+
+| terms | bytes | インタプリタ apply 前 | インタプリタ apply 後 | javacode |
+|---|---|---|---|---|
+| 1 | 1B | 7.64ms | 0.02ms | ~0ms |
+| 2000 | 4KB | 1351ms | 0.06ms | **CompileError** |
+| 6000 | 12KB | 5717ms | **0.19ms** | **CompileError** |
+
+- **javacode は ~4KB 超でコンパイル不能**（JVM の1メソッド 64KB バイトコード上限）。数十KB の式は
+  インタプリタが唯一の現実解。AST キャッシュで繰り返し評価が約3万倍高速化。
+- インタプリタと javacode の同一性は `InterpreterJavacodeParityTest` で共通サブセットを検証
+  （算術・単一boolean・if・比較・match・文字列）。math 関数は javacode 未対応のため対象外。
+
+## 2. 追加テスト
+
+- `GrammarCoverageInterpreterTest` — 文法由来の式と実行時の答えを網羅（算術・math関数・boolean
+  優先順位 OR&lt;AND&lt;XOR・not入れ子・if/ternary/match・文字列・変数・キャッシュ整合）。高速インタプリタ実行。
+- `InterpreterJavacodeParityTest` — インタプリタ↔javacode のパリティ証明（共通サブセット）。
+- `KnownP4BugsTest` — 下記バグの再現（@Ignore、修正後に外せば回帰検知になる）。
+- `BackendSpeedBenchmarkTest` — 性能ベンチ（@Ignore、手動実行用）。
+
+## 3. 発見した P4 インタプリタのバグ（master 現状で再現）
+
+| ID | 症状 | 再現テスト |
+|---|---|---|
+| tinyexpression#25 | top-level の `not(...)` を `_boolean` 評価すると常に false（`if` 内は正常、javacodeは正しい）。外側 NotExpr が root マッピングで脱落する疑い | `KnownP4BugsTest.standaloneNotReturnsFalse` |
+| tinyexpression#21 | `min/max` の3引数以上（P4は正しく1だが cross-check が壊れた legacy=3 を優先）、`if(1>0\|0>1&1>2)` の優先順位も同様に legacy で上書き | `variadicMinMax` / `booleanPrecedenceInIf` |
+| unlaxer-parser#43 | `abs(-3)+pow(2,3)` 等 math 関数を含む算術。生成 `BinaryExpr` レコードのオペランド型が `BinaryExpr` 固定で MathFunction を保持できず誤評価 | `functionTermArithmetic` |
+
+ネスト ternary `(true ? (false ? 1 : 2) : 3)` は master で正しく評価される（`nestedTernary` は通常テストとして保持）。
+
+## 4. 関連 issue（unlaxer-parser, 別リポジトリ）
+
+- **#41** GrammarValidator: ルール名 vs トークンパーサクラス名の衝突を generate 時にエラー化
+  （master は症状をインライン化で回避したが検出ガードは無い）。→ 実装済み（unlaxer-parser ブランチ）。
+- **#42** MapperGenerator: リテラル`@value`の WordParser キャッチオール衝突（paren-boolean 誤捕捉）。
+  → 実装したが master の新 boolean 文法と相性問題があり再検証が必要。本ブランチには含めない。
+
+## 5. テスト速度に関する補足
+
+surefire の `forkCount` 並列化を試したが、複数の既存テストがプロセス横断の静的状態
+（`JavaCodeBlockPolicy`、`Parser.get` キャッシュ）を共有しており並列フォークで落ちるため**採用しない**。
+速度は AST キャッシュ（インタプリタ本流化）と `-Dtinyexpression.skipRailroad=true` で確保する。
+
+## 6. テスト不安定性の調査（既存 master の問題）
+
+ローカルで一部の既存テストが master 単体でも失敗する。調査した根本原因は以下（**いずれも本ブランチの
+変更とは無関係。本ブランチは clean master 比で新規失敗を追加しない**）:
+
+### 6.1 グローバル静的 `JavaCodeBlockPolicy` の実行順依存（主因）
+`JavaCodeBlockPolicy.ENABLED` はプロセス全体で共有される `AtomicBoolean`、デフォルト false
+（secure-by-default）。Java コードブロック式（例: CheckDigits）を使うテスト
+（`FormulaInfoParserTest`, `FormulaInfoListTest`, `TinyExpressionsExecutorTest` 等）は
+ポリシー有効化が必要だが**自分で `setEnabled(true)` を呼ばず**、別テストが有効化した状態に暗黙依存している。
+`JavaCodeBlockPolicyTest` は @Before/@After で `reset()`（→false）するため、その後に走るこれらのテストは
+`CompileError: Java code block execution is disabled` で落ちる。
+
+結果として: (a) 実行順依存（CI の順序ではたまたま緑）、(b) 単体実行で落ちる、(c) **surefire forkCount 並列で
+クラス分散が変わると落ちる**。これが §5 の forkCount 不採用の根本理由でもある。
+
+**修正案**: コードブロックを使うテストは各自の @Before で `JavaCodeBlockPolicy.setEnabled(true)`、@After で
+`reset()` を呼び、自己完結させる（順序・並列非依存になり、forkCount 高速化も解禁できる）。→ tinyexpression#26
+
+### 6.2 `Parser.get` 等のプロセス横断シングルトン
+パーサ/評価器がプロセス全体のシングルトンキャッシュを共有するため、reuseForks 並列でクラス間が干渉しうる。
+6.1 と併せて並列実行を不安定にする。
+
+### 6.3 陳腐化した生成コードコーパス（policy 無関係）
+`DslJavaCodeGenerationExtractedParityTest.testExtractedLegacyCorpusJavaCodeParity` は、コミット済みの
+期待 Java コードコーパスと現 codegen 出力の差で落ちる（例: `(1+1)/5` の括弧出力が
+`([1.0f+1.0f])` vs `([(1.0f+1.0f)])`）。テスト不安定性ではなくゴールデン陳腐化。要コーパス再生成。

--- a/docs/findings-2026-06-15-unlaxer-3.0.4-and-p4.md
+++ b/docs/findings-2026-06-15-unlaxer-3.0.4-and-p4.md
@@ -76,7 +76,7 @@ surefire の `forkCount` 並列化を試したが、複数の既存テストが�
 クラス分散が変わると落ちる**。これが §5 の forkCount 不採用の根本理由でもある。
 
 **修正案**: コードブロックを使うテストは各自の @Before で `JavaCodeBlockPolicy.setEnabled(true)`、@After で
-`reset()` を呼び、自己完結させる（順序・並列非依存になり、forkCount 高速化も解禁できる）。→ tinyexpression#26
+`reset()` を呼び、自己完結させる（順序・並列非依存になり、forkCount 高速化も解禁できる）。→ tinyexpression#27
 
 ### 6.2 `Parser.get` 等のプロセス横断シングルトン
 パーサ/評価器がプロセス全体のシングルトンキャッシュを共有するため、reuseForks 並列でクラス間が干渉しうる。

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
 		<tinyexpression.p4.grammar>${project.basedir}/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf</tinyexpression.p4.grammar>
 		<tinyexpression.p4.generated.runtime>${project.basedir}/target/generated-sources/tinyexpression-p4/runtime</tinyexpression.p4.generated.runtime>
 		<tinyexpression.p4.railroad.output>${project.basedir}/docs/railroad</tinyexpression.p4.railroad.output>
+		<!-- Railroad SVG generation is documentation-only; skip with -Dtinyexpression.skipRailroad=true to speed up dev/test iteration -->
+		<tinyexpression.skipRailroad>false</tinyexpression.skipRailroad>
 	</properties>
 
 	<dependencies>
@@ -141,7 +143,8 @@
 							<goal>java</goal>
 						</goals>
 						<configuration>
-							<mainClass>org.unlaxer.dsl.tools.railroad.RailroadMain</mainClass>
+							<skip>${tinyexpression.skipRailroad}</skip>
+						<mainClass>org.unlaxer.dsl.tools.railroad.RailroadMain</mainClass>
 							<arguments>
 								<argument>${tinyexpression.p4.grammar}</argument>
 								<argument>${tinyexpression.p4.railroad.output}</argument>
@@ -178,6 +181,11 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.2.5</version>
 				<configuration>
+					<!-- NOTE: surefire forkCount parallelism was tried for speed but several
+					     existing tests share process-wide static state (JavaCodeBlockPolicy,
+					     Parser.get cache) and fail when classes run in parallel forks, so it is
+					     intentionally NOT enabled. Test speed comes from the AST cache and from
+					     -Dtinyexpression.skipRailroad=true instead. -->
 					<!-- ハング時の安全弁 (issue #19): フォークが45分応答しなければ kill して fail にする -->
 					<forkedProcessTimeoutInSeconds>5400</forkedProcessTimeoutInSeconds>
 					<excludes>

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
@@ -70,6 +70,14 @@ public class AstEvaluatorCalculator implements Calculator {
 
   private final boolean generatedAstRuntimeAvailable;
 
+  // Performance: the P4 primary path re-parses and re-maps the formula on every apply().
+  // For large formulas (tens of KB) re-parsing dominates (seconds per eval). Once the
+  // typed P4 path has successfully evaluated a declaration-free formula, its parsed AST
+  // is structurally stable and reusable across apply() calls (only the CalculationContext
+  // varies), so we cache it and evaluate it directly. The primary P4TypedAstEvaluator does
+  // not depend on the mapper's per-parse NODE_SOURCE_SPANS, so reusing a cached AST is safe.
+  private volatile TinyExpressionP4AST cachedTypedAst;
+
   public AstEvaluatorCalculator(Source source, String className,
       SpecifiedExpressionTypes specifiedExpressionTypes, ClassLoader classLoader) {
     this.source = source;
@@ -237,6 +245,22 @@ public class AstEvaluatorCalculator implements Calculator {
     // The fallback chain below is retained as a safety net.
     // If you see _p4FallbackReason in production, it indicates a regression.
     // =========================================================================
+    // FAST PATH: reuse the cached typed AST (no re-parse / re-map). Only populated for
+    // declaration-free formulas the typed evaluator has already handled, so the guards
+    // that gated the primary path below were already satisfied for this (constant) source.
+    TinyExpressionP4AST cached = cachedTypedAst;
+    if (cached != null) {
+      Object cachedResult = new P4TypedAstEvaluator(
+          specifiedExpressionTypes, calculationContext, source.source(), classLoader).eval(cached);
+      if (cachedResult != null) {
+        setObject("_astEvaluatorRuntime", "p4-typed");
+        setObject("_astEvaluatorMapperAvailable", true);
+        setObject("_astEvaluatorGeneratedEmbeddedBridgeUsed", false);
+        return cachedResult;
+      }
+      cachedTypedAst = null; // unexpected null — drop cache and fall through
+    }
+
     Optional<Object> tokenAstEvaluated = Optional.empty();
     if (generatedAstRuntimeAvailable
         && !syntheticInvocationFormula
@@ -280,6 +304,11 @@ public class AstEvaluatorCalculator implements Calculator {
                 setObject("_astEvaluatorRuntime", "p4-typed");
                 setObject("_astEvaluatorMapperAvailable", true);
                 setObject("_astEvaluatorGeneratedEmbeddedBridgeUsed", false);
+                // Cache the parsed AST for declaration-free formulas so subsequent
+                // apply() calls skip the (potentially very expensive) re-parse.
+                if (!hasDeclarations) {
+                  cachedTypedAst = typedAst;
+                }
                 return p4TypedEvaluated.get();
               }
             } else {

--- a/src/test/java/org/unlaxer/tinyexpression/BackendSpeedBenchmarkTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/BackendSpeedBenchmarkTest.java
@@ -1,0 +1,92 @@
+package org.unlaxer.tinyexpression;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.unlaxer.tinyexpression.evaluator.javacode.SpecifiedExpressionTypes;
+import org.unlaxer.tinyexpression.loader.model.CalculatorCreator;
+import org.unlaxer.tinyexpression.loader.model.CalculatorCreatorRegistry;
+import org.unlaxer.tinyexpression.parser.ExpressionTypes;
+
+/**
+ * NON-ASSERTING micro-benchmark: compares P4 interpreter (AST_EVALUATOR / P4-typed)
+ * vs compiled javacode (JAVA_CODE) for create-time and per-apply-time across
+ * expression sizes (small / ~KB / ~tens-of-KB).
+ *
+ * Findings to read from stdout:
+ *  - javacode pays a large one-time javac cost that grows with formula size and
+ *    can hit the JVM 64KB-per-method bytecode limit for very large formulas.
+ *  - the interpreter currently RE-PARSES + RE-MAPS on every apply() (no AST cache),
+ *    so its per-apply cost grows with size and is paid on every evaluation.
+ */
+public class BackendSpeedBenchmarkTest {
+
+  /** number of '+1' terms -> rough size control */
+  static final int[] TERMS = {1, 200, 2000, 6000};
+
+  @Ignore("manual performance benchmark — run explicitly with -Dtest=BackendSpeedBenchmarkTest")
+  @Test
+  public void benchmark() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    SpecifiedExpressionTypes num =
+        new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
+
+    System.out.println("\n================= BACKEND SPEED BENCHMARK =================");
+    System.out.printf("%-9s %-7s | %-22s | %-22s%n", "terms", "bytes", "INTERPRETER (p4-typed)", "JAVACODE (compiled)");
+    System.out.printf("%-9s %-7s | %-10s %-11s | %-10s %-11s%n", "", "", "create", "apply(avg)", "create", "apply(avg)");
+    System.out.println("----------------------------------------------------------------------------");
+
+    for (int n : TERMS) {
+      String formula = buildArith(n);
+      Row interp = measure(CalculatorCreatorRegistry.astEvaluatorCreator(), formula, num, cl);
+      Row java = measure(CalculatorCreatorRegistry.javaCodeCreator(), formula, num, cl);
+      System.out.printf("%-9d %-7d | %-10s %-11s | %-10s %-11s%n",
+          n, formula.length(), interp.create, interp.apply, java.create, java.apply);
+    }
+    System.out.println("============================================================\n");
+  }
+
+  static String buildArith(int terms) {
+    StringBuilder sb = new StringBuilder("1");
+    for (int i = 1; i < terms; i++) sb.append("+1");
+    return sb.toString();
+  }
+
+  static class Row {
+    String create = "-";
+    String apply = "-";
+  }
+
+  private Row measure(CalculatorCreator creator, String formula, SpecifiedExpressionTypes types, ClassLoader cl) {
+    Row row = new Row();
+    Calculator calc;
+    try {
+      long t0 = System.nanoTime();
+      calc = creator.create(new Source(formula), "Bench_" + Math.abs(formula.hashCode()), types, cl);
+      // create() may be lazy; force the first apply to include compile/parse cost
+      Object first = calc.apply(CalculationContext.newConcurrentContext());
+      long t1 = System.nanoTime();
+      row.create = ms(t1 - t0) + (first == null ? "(null)" : "");
+    } catch (Throwable t) {
+      row.create = "ERR:" + t.getClass().getSimpleName();
+      return row;
+    }
+    try {
+      // warm apply: average over iterations
+      int iters = 20;
+      CalculationContext ctx = CalculationContext.newConcurrentContext();
+      // a couple of warmups
+      for (int i = 0; i < 3; i++) calc.apply(ctx);
+      long t0 = System.nanoTime();
+      for (int i = 0; i < iters; i++) calc.apply(ctx);
+      long t1 = System.nanoTime();
+      row.apply = ms((t1 - t0) / iters);
+    } catch (Throwable t) {
+      row.apply = "ERR:" + t.getClass().getSimpleName();
+    }
+    return row;
+  }
+
+  static String ms(long nanos) {
+    return String.format("%.2fms", nanos / 1_000_000.0);
+  }
+}

--- a/src/test/java/org/unlaxer/tinyexpression/GrammarCoverageInterpreterTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/GrammarCoverageInterpreterTest.java
@@ -1,0 +1,254 @@
+package org.unlaxer.tinyexpression;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.unlaxer.tinyexpression.evaluator.javacode.SpecifiedExpressionTypes;
+import org.unlaxer.tinyexpression.loader.model.CalculatorCreatorRegistry;
+import org.unlaxer.tinyexpression.parser.ExpressionTypes;
+
+/**
+ * Comprehensive grammar-derived coverage, run on the FAST P4-typed interpreter
+ * (AST_EVALUATOR backend). Every case is a real formula paired with its runtime
+ * answer. Heavy emphasis on boolean nesting (not / nested & | ^) and operator
+ * precedence, which is the area users reported problems with.
+ *
+ * Boolean precedence follows the UBNF grammar: OR (loosest) &lt; AND &lt; XOR (tightest).
+ * i.e. `a | b & c`  == `a | (b & c)` ; `a ^ b & c` == `(a ^ b) & c` ... wait — XOR is
+ * tightest so `a & b ^ c` == `a & (b ^ c)` and `a ^ b & c` == `(a ^ b) & c`.
+ *
+ * Comparisons combined with boolean operators are written inside if(...) because a
+ * bare top-level `1>0 & 2>1` is shadowed by NumberExpression in the Expression rule
+ * (documented limitation — see findings doc).
+ */
+public class GrammarCoverageInterpreterTest {
+
+  private final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+  // ───────────────────────── arithmetic ─────────────────────────
+  @Test public void arithmetic() {
+    assertNum("1+1", 2);
+    assertNum("2+3*4", 14);
+    assertNum("(2+3)*4", 20);
+    assertNum("10-2*3", 4);
+    assertNum("1+8/4", 3);
+    assertNum("(10-2)*(7-3)", 32);
+    assertNum("2*3+4*5", 26);
+    assertNum("100/10/2", 5);
+    assertNum("2-3-4", -5);            // left assoc
+    assertNum("3.5+1.5", 5);
+    assertNum("10/4", 2.5f);
+  }
+
+  // ───────────────────────── math functions ─────────────────────
+  @Test public void mathFunctions() {
+    assertNum("sqrt(9)", 3);
+    assertNum("abs(-7)", 7);
+    assertNum("abs(5)", 5);
+    assertNum("round(2.6)", 3);
+    assertNum("round(2.4)", 2);
+    assertNum("floor(3.9)", 3);
+    assertNum("floor(-1.1)", -2);
+    assertNum("ceil(3.1)", 4);
+    assertNum("ceil(-3.9)", -3);
+    assertNum("pow(2,10)", 1024);
+    assertNum("pow(3,2)", 9);
+    assertNum("min(3,5)", 3);
+    assertNum("max(3,5)", 5);
+    // NOTE: min/max with >2 args are broken — see KnownP4BugsTest.variadicMinMax.
+    assertNum("log(1)", 0);
+    assertNum("exp(0)", 1);
+    // NOTE: `abs(-3)+pow(2,3)` (arithmetic combining function-call terms) is broken by
+    // the cross-check — see KnownP4BugsTest.crossCheckDropsFunctionArithmetic.
+  }
+
+  // ───────────────────────── boolean literals & single ops ──────
+  @Test public void booleanSingleOps() {
+    assertBool("true", true);
+    assertBool("false", false);
+    assertBool("true & false", false);
+    assertBool("true & true", true);
+    assertBool("true | false", true);
+    assertBool("false | false", false);
+    assertBool("true ^ false", true);
+    assertBool("true ^ true", false);
+    // NOTE: standalone top-level `not(...)` as a _boolean formula is broken on the P4
+    // interpreter (always false) — see KnownP4BugsTest.standaloneNotReturnsFalse /
+    // tinyexpression#25. `not` is exercised via the working if(...) form in notNesting.
+  }
+
+  // ───────────────────────── boolean PRECEDENCE (OR<AND<XOR) ─────
+  @Test public void booleanPrecedence() {
+    // AND binds tighter than OR: a | b & c == a | (b&c)
+    assertBool("true | false & false", true);
+    assertBool("false | true & true", true);
+    assertBool("false | false & true", false);
+    // XOR binds tighter than AND: a & b ^ c == a & (b^c)
+    assertBool("true & false ^ true", true);     // true & (false^true) = true&true
+    assertBool("true & true ^ true", false);     // true & (true^true) = true&false
+    // XOR binds tighter than AND: a ^ b & c == (a^b)... no, & looser than ^, so b&c?
+    // precedence AND(2)<XOR(3): ^ tighter -> a ^ (b & c)? NO: tighter operator groups first.
+    // "true ^ true & false": ^ is tighter so (true^true) then &false = false&false=false
+    assertBool("true ^ true & false", false);
+    assertBool("true ^ false & false", false);   // (true^false)&false = true&false
+    assertBool("false | true ^ true", false);    // false | (true^true) = false|false
+    // long mixed chain
+    assertBool("true | false & false | true", true);
+    assertBool("false ^ false | true & true", true); // (false^false)? no: | loosest. (false^false) | (true&true) = false|true
+  }
+
+  // ───────────────────────── not nesting (nasty) ────────────────
+  // `not` nesting — exercised via the if(...) form because a bare top-level not(...)
+  // formula is broken on the interpreter (tinyexpression#25). 1 = condition true.
+  @Test public void notNesting() {
+    assertNum("if(not(not(true))){1}else{0}", 1);
+    assertNum("if(not(not(not(true)))){1}else{0}", 0);
+    assertNum("if(not(true & false)){1}else{0}", 1);
+    assertNum("if(not(true | false)){1}else{0}", 0);
+    assertNum("if(not(true ^ false)){1}else{0}", 0);
+    assertNum("if(not(true) & not(false)){1}else{0}", 0);
+    assertNum("if(not(false) | not(true)){1}else{0}", 1);
+    assertNum("if(not(true) | not(false)){1}else{0}", 1);
+    assertNum("if(not(not(true) & not(false))){1}else{0}", 1); // not(false & true)=not(false)=true
+    assertNum("if(not(true & true) | not(false)){1}else{0}", 1);
+  }
+
+  // ───────────────────────── parenthesised regrouping ───────────
+  @Test public void booleanParens() {
+    assertBool("(true | false) & false", false);
+    assertBool("true | (false & false)", true);
+    assertBool("(true ^ false) & false", false);
+    assertBool("true ^ (false & false)", true);
+    // NOTE: a parenthesised boolean group used as an AND/XOR operand is mis-mapped
+    // (value captured as the literal "(") — see KnownP4BugsTest.parenthesisedBooleanOperand.
+    // e.g. "(true | false) & (false | true)" and "not((true | false) & false)" are broken.
+  }
+
+  // ───────────────────────── comparisons inside if ──────────────
+  @Test public void comparisonsInIf() {
+    assertNum("if(1>0){1}else{0}", 1);
+    assertNum("if(0>1){1}else{0}", 0);
+    assertNum("if(1>=1){1}else{0}", 1);
+    assertNum("if(1<=0){1}else{0}", 0);
+    assertNum("if(2==2){1}else{0}", 1);
+    assertNum("if(2!=3){1}else{0}", 1);
+    assertNum("if(1>0 & 2>1){1}else{0}", 1);
+    assertNum("if(1>0 & 2>3){1}else{0}", 0);
+    assertNum("if(1>0 | 2>3){1}else{0}", 1);
+    assertNum("if(1>2 | 3>4){1}else{0}", 0);
+    assertNum("if(1>0 & 2>1 & 3>2){1}else{0}", 1);
+    // NOTE: `if(1>0 | 0>1 & 1>2)` (precedence with comparisons) is broken by the
+    // cross-check — see KnownP4BugsTest.crossCheckOverridesCorrectP4Precedence.
+    assertNum("if((1>0 | 0>1) & 1>2){1}else{0}", 0);  // (T|F)&F = F
+    assertNum("if(not(1>2)){1}else{0}", 1);
+    assertNum("if(not(1>0)){1}else{0}", 0);
+    assertNum("if(not(1>2) & not(3>4)){1}else{0}", 1);
+  }
+
+  // ───────────────────────── if / ternary / nested ──────────────
+  @Test public void controlFlow() {
+    assertNum("if(true){1}else{2}", 1);
+    assertNum("if(false){1}else{2}", 2);
+    assertNum("if(2+3>4){1}else{0}", 1);
+    assertNum("(true ? 1 : 2)", 1);
+    assertNum("(false ? 1 : 2)", 2);
+    assertNum("(2>1 ? 10 : 20)", 10);
+    assertNum("if(true){if(false){1}else{2}}else{3}", 2);
+    // NOTE: nested ternary `(true ? (false ? 1 : 2) : 3)` is broken — see
+    // KnownP4BugsTest.nestedTernary.
+    assertNum("abs((true ? -5 : 5))", 5);
+  }
+
+  // ───────────────────────── number match ───────────────────────
+  @Test public void numberMatch() {
+    assertNum("match{ true -> 1, default -> 9 }", 1);
+    assertNum("match{ false -> 1, default -> 9 }", 9);
+    assertNum("match{ 1>2 -> 1, 2>1 -> 2, default -> 9 }", 2);
+    assertNum("match{ 1>2 -> 1, 2>3 -> 2, default -> 9 }", 9);
+  }
+
+  // ───────────────────────── strings ────────────────────────────
+  @Test public void strings() {
+    assertStr("'hello'", "hello");
+    assertStr("'a' + 'b'", "ab");
+    assertStr("'a' + 'b' + 'c'", "abc");
+    assertStr("toUpperCase('abc')", "ABC");
+    assertStr("toLowerCase('ABC')", "abc");
+    assertStr("trim('  x  ')", "x");
+    assertNum("length('hello')", 5);
+  }
+
+  @Test public void stringPredicatesInIf() {
+    assertNum("if('hello' == 'hello'){1}else{0}", 1);
+    assertNum("if('hello' != 'world'){1}else{0}", 1);
+    assertNum("if(startsWith('hello','he')){1}else{0}", 1);
+    assertNum("if(endsWith('hello','lo')){1}else{0}", 1);
+    assertNum("if(contains('hello','ell')){1}else{0}", 1);
+    assertNum("if(startsWith('hello','xx')){1}else{0}", 0);
+  }
+
+  // ───────────────────────── variables (context) ────────────────
+  @Test public void variables() {
+    CalculationContext c = CalculationContext.newConcurrentContext();
+    c.set("x", 10f);
+    c.set("y", 3f);
+    assertNumCtx("$x+$y", 13, c);
+    assertNumCtx("$x*$y", 30, c);
+    assertNumCtx("if($x>$y){1}else{0}", 1, c);
+    assertNumCtx("if($x>$y & $y>0){1}else{0}", 1, c);
+  }
+
+  @Test public void contextValuesAreFreshAcrossApply() {
+    // guards the AST cache: same Calculator, different context -> different result
+    Calculator calc = CalculatorCreatorRegistry.astEvaluatorCreator().create(
+        new Source("$x+1"), "CacheCtx",
+        new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float), cl);
+    CalculationContext c1 = CalculationContext.newConcurrentContext();
+    c1.set("x", 5f);
+    CalculationContext c2 = CalculationContext.newConcurrentContext();
+    c2.set("x", 100f);
+    assertEquals(6f, ((Number) calc.apply(c1)).floatValue(), 0.001f);
+    assertEquals(101f, ((Number) calc.apply(c2)).floatValue(), 0.001f);  // not stale-cached at 6
+    assertEquals(6f, ((Number) calc.apply(c1)).floatValue(), 0.001f);
+  }
+
+  // ───────────────────────── helpers ────────────────────────────
+  private void assertNum(String formula, float expected) {
+    Object r = evalNum(formula, CalculationContext.newConcurrentContext());
+    assertNotNull("null for: " + formula, r);
+    assertTrue("not a Number for: " + formula + " -> " + r, r instanceof Number);
+    assertEquals(formula, expected, ((Number) r).floatValue(), 0.01f);
+  }
+
+  private void assertNumCtx(String formula, float expected, CalculationContext ctx) {
+    Object r = evalNum(formula, ctx);
+    assertNotNull("null for: " + formula, r);
+    assertEquals(formula, expected, ((Number) r).floatValue(), 0.01f);
+  }
+
+  private Object evalNum(String formula, CalculationContext ctx) {
+    Calculator calc = CalculatorCreatorRegistry.astEvaluatorCreator().create(
+        new Source(formula), "Cov_" + Math.abs(formula.hashCode()),
+        new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float), cl);
+    return calc.apply(ctx);
+  }
+
+  private void assertBool(String formula, boolean expected) {
+    Calculator calc = CalculatorCreatorRegistry.astEvaluatorCreator().create(
+        new Source(formula), "CovB_" + Math.abs(formula.hashCode()),
+        new SpecifiedExpressionTypes(ExpressionTypes._boolean, ExpressionTypes._float), cl);
+    Object r = calc.apply(CalculationContext.newConcurrentContext());
+    assertNotNull("null for: " + formula, r);
+    assertEquals(formula, expected, r);
+  }
+
+  private void assertStr(String formula, String expected) {
+    Calculator calc = CalculatorCreatorRegistry.astEvaluatorCreator().create(
+        new Source(formula), "CovS_" + Math.abs(formula.hashCode()),
+        new SpecifiedExpressionTypes(ExpressionTypes.string, ExpressionTypes._float), cl);
+    Object r = calc.apply(CalculationContext.newConcurrentContext());
+    assertEquals(formula, expected, String.valueOf(r));
+  }
+}

--- a/src/test/java/org/unlaxer/tinyexpression/InterpreterJavacodeParityTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/InterpreterJavacodeParityTest.java
@@ -1,0 +1,79 @@
+package org.unlaxer.tinyexpression;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.unlaxer.tinyexpression.evaluator.javacode.SpecifiedExpressionTypes;
+import org.unlaxer.tinyexpression.loader.model.CalculatorCreatorRegistry;
+import org.unlaxer.tinyexpression.parser.ExpressionTypes;
+
+/**
+ * Parity proof: for the set of expressions both backends fully support, the P4-typed
+ * INTERPRETER (AST_EVALUATOR) and the compiled JAVA_CODE backend produce identical
+ * results. This is the justification for running the bulk of coverage on the fast
+ * interpreter (GrammarCoverageInterpreterTest).
+ *
+ * NOTE: parity does NOT hold for every expression — see findings-2026-06-15 §5
+ * (mixed boolean operator precedence: interpreter follows the grammar OR&lt;AND&lt;XOR,
+ * legacy/javacode uses flat left-assoc) and §6 (P4 mapper/cross-check bugs). Those
+ * divergent cases are deliberately excluded here and tracked in KnownP4BugsTest.
+ */
+public class InterpreterJavacodeParityTest {
+
+  private final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+  // NOTE: the JAVA_CODE backend does NOT support the math functions (abs/sqrt/round/
+  // ceil/floor/pow/min/max) that the interpreter supports — `Unsupported parser in
+  // factor: AbsParser`. So parity is only provable on the common subset below; the
+  // interpreter is strictly more capable (findings §4/§8).
+  static final String[] NUMERIC = {
+      "1+1", "2+3*4", "(2+3)*4", "10-2*3", "1+8/4", "(10-2)*(7-3)",
+      "2-3-4", "100/10/2",
+      "if(true){1}else{2}", "if(2+3>4){1}else{0}",
+      "if(1>0 & 2>1){1}else{0}", "if(1>2 | 3>4){1}else{0}",
+      "if(not(1>2)){1}else{0}",
+      "match{ true -> 1, default -> 9 }",
+      "if('a' == 'a'){1}else{0}",
+  };
+
+  // NOTE: standalone top-level `not(...)` is excluded — the interpreter mis-evaluates
+  // it (always false) while javacode is correct, so it is a known divergence, not parity.
+  // Tracked in tinyexpression#25 / KnownP4BugsTest.standaloneNotReturnsFalse.
+  static final String[] BOOLEAN = {
+      "true", "false", "true & false", "true | false", "true ^ false",
+  };
+
+  static final String[] STRING = {
+      "'hello'", "'a' + 'b'", "toUpperCase('abc')", "toLowerCase('ABC')", "trim('  x  ')",
+  };
+
+  @Test public void numericParity() {
+    for (String f : NUMERIC) assertParity(f, ExpressionTypes._float);
+  }
+
+  @Test public void booleanParity() {
+    for (String f : BOOLEAN) assertParity(f, ExpressionTypes._boolean);
+  }
+
+  @Test public void stringParity() {
+    for (String f : STRING) assertParity(f, ExpressionTypes.string);
+  }
+
+  private void assertParity(String formula, ExpressionTypes type) {
+    SpecifiedExpressionTypes t = new SpecifiedExpressionTypes(type, ExpressionTypes._float);
+    Object interp = CalculatorCreatorRegistry.astEvaluatorCreator()
+        .create(new Source(formula), "ParI_" + Math.abs(formula.hashCode()), t, cl)
+        .apply(CalculationContext.newConcurrentContext());
+    Object java = CalculatorCreatorRegistry.javaCodeCreator()
+        .create(new Source(formula), "ParJ_" + Math.abs(formula.hashCode()), t, cl)
+        .apply(CalculationContext.newConcurrentContext());
+    assertEquals("parity mismatch for: " + formula,
+        String.valueOf(normalize(interp)), String.valueOf(normalize(java)));
+  }
+
+  /** normalize numeric types so 3 (Integer) and 3.0 (Float) compare equal. */
+  private Object normalize(Object o) {
+    if (o instanceof Number n) return n.doubleValue();
+    return o;
+  }
+}

--- a/src/test/java/org/unlaxer/tinyexpression/KnownP4BugsTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/KnownP4BugsTest.java
@@ -1,0 +1,86 @@
+package org.unlaxer.tinyexpression;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.unlaxer.tinyexpression.evaluator.javacode.SpecifiedExpressionTypes;
+import org.unlaxer.tinyexpression.loader.model.CalculatorCreatorRegistry;
+import org.unlaxer.tinyexpression.parser.ExpressionTypes;
+
+/**
+ * Reproductions of P4 interpreter (AST_EVALUATOR) correctness bugs found while adding
+ * comprehensive coverage. Each states the CORRECT expected value and is @Ignore'd so
+ * the suite stays green; removing @Ignore turns it into a regression check once fixed.
+ * See docs/findings-2026-06-15-unlaxer-3.0.4-and-p4.md.
+ */
+public class KnownP4BugsTest {
+
+  private final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+  /**
+   * tinyexpression#25: a standalone top-level {@code not(...)} formula evaluated with a
+   * {@code _boolean} result type always returns false on the P4 interpreter (the outer
+   * NotExpr is dropped during root mapping). {@code not(...)} inside {@code if(...)} works,
+   * and the javacode backend is correct.
+   */
+  @Ignore("tinyexpression#25 standalone not(...) top-level returns false")
+  @Test public void standaloneNotReturnsFalse() {
+    assertBool("not(false)", true);
+    assertBool("not(not(true))", true);
+    assertBool("not(1>2)", true);
+  }
+
+  /**
+   * Cross-check defect: the P4-typed interpreter computes min/max of &gt;2 args correctly
+   * (min(3,5,1,9)=1) but AstEvaluatorCalculator cross-checks number results against the
+   * legacy token-AST evaluator (whose variadic min/max is broken, returns 3) and trusts
+   * the legacy value on mismatch. Removing the cross-check is tracked in tinyexpression#21.
+   */
+  @Ignore("tinyexpression#21 cross-check trusts buggy legacy variadic min/max")
+  @Test public void variadicMinMax() {
+    assertNum("min(3,5,1,9)", 1);
+    assertNum("max(3,5,1,9)", 9);
+  }
+
+  /**
+   * Cross-check defect: P4-typed evaluates `1>0 | 0>1 & 1>2` correctly as 1>0|(0>1&1>2)=true,
+   * but the number-result cross-check overrides it with the legacy flat-precedence value.
+   * Tracked in tinyexpression#21.
+   */
+  @Ignore("tinyexpression#21 cross-check overrides correct P4 boolean precedence")
+  @Test public void booleanPrecedenceInIf() {
+    assertNum("if(1>0 | 0>1 & 1>2){1}else{0}", 1);
+  }
+
+  /**
+   * AST-type defect (unlaxer-parser#43): arithmetic combining math-function terms,
+   * e.g. abs(-3)+pow(2,3)=11, is mis-evaluated because the generated BinaryExpr record
+   * types its operands as BinaryExpr (not the common AST interface), so a MathFunction
+   * operand cannot be represented.
+   */
+  @Ignore("unlaxer-parser#43 BinaryExpr operand type too narrow for math-function terms")
+  @Test public void functionTermArithmetic() {
+    assertNum("abs(-3)+pow(2,3)", 11);
+  }
+
+  /** Regression guard: nested ternary is handled correctly on current master. */
+  @Test public void nestedTernary() {
+    assertNum("(true ? (false ? 1 : 2) : 3)", 2);
+  }
+
+  // helpers
+  private void assertNum(String formula, float expected) {
+    Calculator c = CalculatorCreatorRegistry.astEvaluatorCreator().create(
+        new Source(formula), "Bug_" + Math.abs(formula.hashCode()),
+        new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float), cl);
+    assertEquals(formula, expected, ((Number) c.apply(CalculationContext.newConcurrentContext())).floatValue(), 0.01f);
+  }
+
+  private void assertBool(String formula, boolean expected) {
+    Calculator c = CalculatorCreatorRegistry.astEvaluatorCreator().create(
+        new Source(formula), "BugB_" + Math.abs(formula.hashCode()),
+        new SpecifiedExpressionTypes(ExpressionTypes._boolean, ExpressionTypes._float), cl);
+    assertEquals(formula, expected, c.apply(CalculationContext.newConcurrentContext()));
+  }
+}

--- a/src/test/java/org/unlaxer/tinyexpression/parser/UserFormulaParseTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/parser/UserFormulaParseTest.java
@@ -1,0 +1,186 @@
+package org.unlaxer.tinyexpression.parser;
+
+import java.io.PrintStream;
+
+import org.junit.Test;
+import org.unlaxer.Parsed;
+import org.unlaxer.StringSource;
+import org.unlaxer.Token;
+import org.unlaxer.context.ParseContext;
+import org.unlaxer.parser.Parser;
+
+public class UserFormulaParseTest {
+
+  // The original formula the user reported as a parse error.
+  static final String ORIGINAL =
+      "import jp.caulis.nimt.customfunction.sideeffect.AccountEventHistoryFilter#filterByEventTypeAndDuration as filterByEventTypeAndDuration;\n"
+    + "import jp.caulis.nimt.customfunction.sideeffect.AccountEventHistoryFilter#filterByAnySuspiciousKey as filterByAnySuspiciousKey;\n"
+    + "import jp.caulis.nimt.customfunction.sideeffect.AccountEventHistoryFilter#filterByAnyChangedItem as filterByAnyChangedItem;\n"
+    + "\n"
+    + "if ($endpoint == 'withdrawal'\n"
+    + "    // No1\n"
+    + "    // 30分以内のログインイベントを抽出\n"
+    + "    & external:filterByEventTypeAndDuration('No2_No1', 'login', ($oneMinute * 30)) >= 1\n"
+    + "    // 初回プロバイダー,端末IDを抽出\n"
+    + "    & external:filterByAnySuspiciousKey('No2_No1', 'FirstProvider', 'FirstLoggedInTerminal') >= 1\n"
+    + "\n"
+    + "    // No2\n"
+    + "    // 30分以内の基本情報変更イベントを抽出\n"
+    + "    & external:filterByEventTypeAndDuration('No2_No2', 'informationChange', ($oneMinute * 30)) >= 1\n"
+    + "    // 大和ネクスト銀行で登録のメールアドレスの登録／変更 または 大和ネクスト銀行の振込限度額の変更\n"
+    + "    & (external:filterByAnyChangedItem('No2_No2', 'email_primary', 'email_sub1', 'email_sub2', 'email_sub3') >= 1\n"
+    + "    | $calculated_OriginalSpec_LastTransferLimitIncreased > 0.0)\n"
+    + "\n"
+    + "    // No3\n"
+    + "    // 振込先口座（仕向先口座）の受取人名と預金者名義が異なる ただし口座名義人名と同じ名字が振込先口座に含まれている場合は除外\n"
+    + "    & $calculated_OriginalSpec_IsAccountHolderNameMismatchExceptForIncludeSurname > 0.0\n"
+    + "  ) {\n"
+    + "  1\n"
+    + "} else {\n"
+    + "  0\n"
+    + "}";
+
+  @Test
+  public void original() {
+    parseAndReport("ORIGINAL", ORIGINAL);
+  }
+
+  // Hypothesis 1: add `returning as number :` to every external call.
+  @Test
+  public void variant_withReturningAs() {
+    String formula = ORIGINAL
+        .replace("external:filterByEventTypeAndDuration(",
+                 "external returning as number : filterByEventTypeAndDuration(")
+        .replace("external:filterByAnySuspiciousKey(",
+                 "external returning as number : filterByAnySuspiciousKey(")
+        .replace("external:filterByAnyChangedItem(",
+                 "external returning as number : filterByAnyChangedItem(");
+    parseAndReport("WITH returning as number", formula);
+  }
+
+  // Hypothesis 2: drop the line comments.
+  @Test
+  public void variant_noLineComments() {
+    String formula = stripLineComments(ORIGINAL);
+    parseAndReport("NO line comments", formula);
+  }
+
+  // Hypothesis 3: drop the extra parentheses around `($oneMinute * 30)`.
+  @Test
+  public void variant_noParenAroundMul() {
+    String formula = ORIGINAL.replace("($oneMinute * 30)", "$oneMinute * 30");
+    parseAndReport("NO outer parens around $oneMinute*30", formula);
+  }
+
+  // Hypothesis 4: combine 1+2+3.
+  @Test
+  public void variant_allFixes() {
+    String formula = ORIGINAL
+        .replace("external:filterByEventTypeAndDuration(",
+                 "external returning as number : filterByEventTypeAndDuration(")
+        .replace("external:filterByAnySuspiciousKey(",
+                 "external returning as number : filterByAnySuspiciousKey(")
+        .replace("external:filterByAnyChangedItem(",
+                 "external returning as number : filterByAnyChangedItem(");
+    formula = stripLineComments(formula);
+    formula = formula.replace("($oneMinute * 30)", "$oneMinute * 30");
+    parseAndReport("ALL fixes", formula);
+  }
+
+  // Tiny isolated cases.
+  @Test
+  public void minimal_externalAlias_noReturning() {
+    String formula =
+        "import a.b.C#m as m;\n"
+      + "external:m(1)";
+    parseAndReport("MINIMAL external:alias(...)", formula);
+  }
+
+  @Test
+  public void minimal_externalAlias_withReturning() {
+    String formula =
+        "import a.b.C#m as m;\n"
+      + "external returning as number : m(1)";
+    parseAndReport("MINIMAL external returning as number : alias(...)", formula);
+  }
+
+  @Test
+  public void minimal_externalFqcn_noReturning() {
+    String formula = "external:a.b.C#m(1)";
+    parseAndReport("MINIMAL external:Class#method(...)", formula);
+  }
+
+  static String stripLineComments(String input) {
+    StringBuilder sb = new StringBuilder();
+    boolean inLine = false;
+    boolean inSingle = false;
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      char n = i + 1 < input.length() ? input.charAt(i + 1) : '\0';
+      if (inLine) {
+        if (c == '\n') {
+          inLine = false;
+          sb.append(c);
+        }
+        continue;
+      }
+      if (!inSingle && c == '/' && n == '/') {
+        inLine = true;
+        i++;
+        continue;
+      }
+      if (c == '\'' && (i == 0 || input.charAt(i - 1) != '\\')) inSingle = !inSingle;
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+
+  static void parseAndReport(String label, String formula) {
+    System.out.println("============================================================");
+    System.out.println("CASE: " + label);
+    System.out.println("------------------------------------------------------------");
+    System.out.println(formula);
+    System.out.println("------------------------------------------------------------");
+
+    try (ParseContext parseContext = new ParseContext(StringSource.createRootSource(formula))) {
+      FormulaParser formulaParser = Parser.get(FormulaParser.class);
+      Parsed parsed;
+      try {
+        parsed = formulaParser.parse(parseContext);
+      } catch (Throwable t) {
+        System.out.println("RESULT: THROWN " + t.getClass().getSimpleName() + ": " + t.getMessage());
+        return;
+      }
+
+      boolean ok = parsed.isSucceeded() && parseContext.allConsumed();
+      System.out.println("RESULT: " + (ok ? "OK" : "FAIL")
+          + "  succeeded=" + parsed.isSucceeded()
+          + "  allConsumed=" + parseContext.allConsumed());
+      if (!ok) {
+        Token root = parsed.getRootToken();
+        if (root != null) {
+          int consumed = root.tokenRange == null ? -1 : root.tokenRange.endIndexExclusive;
+          System.out.println("Consumed up to index: " + consumed + " (of " + formula.length() + ")");
+          if (consumed >= 0 && consumed < formula.length()) {
+            int from = Math.max(0, consumed - 20);
+            int to = Math.min(formula.length(), consumed + 40);
+            System.out.println("Around failure: ..." + formula.substring(from, to).replace("\n", "\\n") + "...");
+          }
+          System.out.println("--- token tree ---");
+          output(root, System.out, 0);
+        }
+      }
+    }
+  }
+
+  static void output(Token token, PrintStream out, int level) {
+    if (!token.tokenString.isPresent()) return;
+    for (int i = 0; i < level; i++) out.print(" ");
+    String s = token.tokenString.get();
+    if (s.length() > 60) s = s.substring(0, 57) + "...";
+    out.format("%s : %s%n", s.replace("\n", "\\n"), token.parser.getClass().getSimpleName());
+    if (!token.filteredChildren.isEmpty()) {
+      for (Token child : token.filteredChildren) output(child, out, level + 1);
+    }
+  }
+}


### PR DESCRIPTION
現 master の P4 実装の上に性能改善とテストを追加。詳細: docs/findings-2026-06-15-unlaxer-3.0.4-and-p4.md

## 主な変更
- **AST キャッシュ** (`AstEvaluatorCalculator.cachedTypedAst`): apply ごとの再パースを回避。12KB式の繰り返し評価 5717ms→0.19ms。javacode は ~4KB 超でコンパイル不能(64KBメソッド上限)のため巨大式はインタプリタが唯一解。
- **テスト追加**: GrammarCoverageInterpreterTest(文法網羅・高速インタプリタ), InterpreterJavacodeParityTest(共通サブセットで interpreter==javacode 証明), KnownP4BugsTest(@Ignore・発見バグ再現), BackendSpeedBenchmarkTest(@Ignore・ベンチ)。
- pom: `-Dtinyexpression.skipRailroad` 追加。forkCount 並列は**不採用**(下記 §6 のテスト隔離問題)。

## 発見したバグ(issue 化済み)
- #25 standalone `not(...)` が _boolean で常に false(if内は正常)
- #21 cross-check が variadic min/max・boolean優先順位を壊れた legacy で上書き
- unlaxer-parser#43 `abs(-3)+pow(2,3)` 等 math関数算術(BinaryExpr オペランド型が狭い)

## テスト不安定性の調査
`JavaCodeBlockPolicy` のグローバル静的状態の実行順依存が主因(findings §6)。本PRは clean master 比で**新規失敗ゼロ**(検証済み範囲)。ローカルでは master 自体が一部環境要因で赤いため、CI での緑判定を依頼します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)