### PR TITLE
test: JavaCodeBlockPolicy の順序依存を修正（テスト不安定性 #27）

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
 		<tinyexpression.p4.grammar>${project.basedir}/tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf</tinyexpression.p4.grammar>
 		<tinyexpression.p4.generated.runtime>${project.basedir}/target/generated-sources/tinyexpression-p4/runtime</tinyexpression.p4.generated.runtime>
 		<tinyexpression.p4.railroad.output>${project.basedir}/docs/railroad</tinyexpression.p4.railroad.output>
+		<!-- Railroad SVG generation is documentation-only; skip with -Dtinyexpression.skipRailroad=true -->
+		<tinyexpression.skipRailroad>false</tinyexpression.skipRailroad>
+		<!-- Forked JVMs surefire uses to run test classes. Default 1 (serial, stable).
+		     Opt into parallel speed with -Dte.forkCount=0.5C, but note some tests still
+		     share process-wide state and may fail under parallel forks (see findings §6). -->
+		<te.forkCount>1</te.forkCount>
 	</properties>
 
 	<dependencies>
@@ -141,6 +147,7 @@
 							<goal>java</goal>
 						</goals>
 						<configuration>
+							<skip>${tinyexpression.skipRailroad}</skip>
 							<mainClass>org.unlaxer.dsl.tools.railroad.RailroadMain</mainClass>
 							<arguments>
 								<argument>${tinyexpression.p4.grammar}</argument>
@@ -179,7 +186,9 @@
 				<version>3.2.5</version>
 				<configuration>
 					<!-- ハング時の安全弁 (issue #19): フォークが45分応答しなければ kill して fail にする -->
-					<forkedProcessTimeoutInSeconds>5400</forkedProcessTimeoutInSeconds>
+					<forkCount>${te.forkCount}</forkCount>
+						<reuseForks>true</reuseForks>
+						<forkedProcessTimeoutInSeconds>5400</forkedProcessTimeoutInSeconds>
 					<excludes>
 						<!-- issue #20: legacy パーサーの指数バックトラックを意図的に繰り返す
 						     ベンチマーク。unlaxer のメモ化 (unlaxer-parser#40) 導入まで除外。

--- a/src/test/java/org/unlaxer/tinyexpression/instances/TinyExpressionsExecutorTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/instances/TinyExpressionsExecutorTest.java
@@ -10,10 +10,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.unlaxer.tinyexpression.CalculationContext;
 import org.unlaxer.tinyexpression.Calculator;
+import org.unlaxer.tinyexpression.evaluator.javacode.JavaCodeBlockPolicy;
 import org.unlaxer.tinyexpression.loader.FormulaInfoAdditionalFields;
 import org.unlaxer.tinyexpression.loader.model.FormulaInfo;
 
@@ -29,6 +32,11 @@ public class TinyExpressionsExecutorTest {
   public static void setup() {
     System.setProperty("--add-opens", "java.base/java.lang=ALL-UNNAMED");
   }
+
+  // Formulas here include Java code blocks (CheckDigits); opt in to the process-wide
+  // policy so the test is order-/parallelism-independent (tinyexpression#27).
+  @Before public void enableJavaCodeBlocks() { JavaCodeBlockPolicy.setEnabled(true); }
+  @After public void resetJavaCodeBlocks() { JavaCodeBlockPolicy.reset(); }
 
   /*
    * Test用の簡易的なCheckResult class

--- a/src/test/java/org/unlaxer/tinyexpression/loader/FormulaInfoParserTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/loader/FormulaInfoParserTest.java
@@ -4,14 +4,24 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.unlaxer.tinyexpression.Calculator;
+import org.unlaxer.tinyexpression.evaluator.javacode.JavaCodeBlockPolicy;
 import org.unlaxer.tinyexpression.instances.FileBaseTinyExpressionInstancesCache;
 import org.unlaxer.tinyexpression.instances.TenantID;
 import org.unlaxer.tinyexpression.instances.TinyExpressionsExecutorTest.NameAndDependsOnComparator;
 import org.unlaxer.tinyexpression.loader.model.FormulaInfo;
 
 public class FormulaInfoParserTest {
+
+  // The test fixtures contain Java code-block formulas (CheckDigits). The policy is a
+  // process-wide static flag (default off, secure-by-default), so each test that needs
+  // code blocks must opt in itself — relying on another test having enabled it makes the
+  // suite order-/parallelism-dependent (tinyexpression#27).
+  @Before public void enableJavaCodeBlocks() { JavaCodeBlockPolicy.setEnabled(true); }
+  @After public void resetJavaCodeBlocks() { JavaCodeBlockPolicy.reset(); }
 
   @Test
   public void test() {

--- a/src/test/java/org/unlaxer/tinyexpression/loader/model/FormulaInfoListTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/loader/model/FormulaInfoListTest.java
@@ -9,12 +9,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.unlaxer.tinyexpression.evaluator.javacode.JavaCodeBlockPolicy;
 import org.unlaxer.tinyexpression.loader.FormulaInfoAdditionalFields;
 import org.unlaxer.util.StringUtils;
 import org.unlaxer.util.Try;
 
 public class FormulaInfoListTest {
+
+  // Fixtures contain Java code-block formulas; opt in to the process-wide policy so the
+  // test is order-/parallelism-independent (tinyexpression#27).
+  @Before public void enableJavaCodeBlocks() { JavaCodeBlockPolicy.setEnabled(true); }
+  @After public void resetJavaCodeBlocks() { JavaCodeBlockPolicy.reset(); }
 
   @Test
   public void test() throws IOException {


### PR DESCRIPTION
## 問題
`JavaCodeBlockPolicy.ENABLED` はプロセス全体共有の静的フラグ（default false, secure-by-default）。Java コードブロック式（CheckDigits）を使う `FormulaInfoParserTest`/`FormulaInfoListTest`/`TinyExpressionsExecutorTest` は**自分で有効化せず**、別テストが残した状態に依存していた。`JavaCodeBlockPolicyTest` が @Before/@After で reset するため、**実行順・単体実行・並列フォークで `CompileError: Java code block execution is disabled` で失敗**していた（CI が緑なのはたまたまの順序）。

## 修正
該当3テストに `@Before setEnabled(true)` / `@After reset()` を追加し自己完結化。順序・並列非依存になる。
**検証**: `JavaCodeBlockPolicyTest` + 該当3テストを直列同一実行で 11/0 パス。

## pom
- `-Dtinyexpression.skipRailroad` 追加（ドキュメント用SVG生成スキップ）
- `-Dte.forkCount` をオプトイン化（default 1=直列・安定。並列は他テストのプロセス横断状態共有で不安定なため要注意。詳細 docs/findings §6）

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)