### PR TITLE
fix(p4): bare boolean比較パース(#23) / standalone not(#25) / runtimeタグ(#30)

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
@@ -422,7 +422,12 @@ public class AstEvaluatorCalculator implements Calculator {
         AstDeclarationRuntime.applyDeclarations(source.source(), specifiedExpressionTypes, calculationContext, classLoader);
       }
       String declarationRuntime = declarationEvaluated.get().runtime();
-      if (isKnownDeclarationLiteralFormula(formulaText)
+      // Only relabel to "generated-ast" when the generated runtime is actually available.
+      // Previously this relabelled unconditionally, mislabelling the runtime tag when the
+      // generated runtime was absent (e.g. blocked classloader) — the result was correct
+      // but the reported runtime lied. (tinyexpression#30)
+      if (generatedAstRuntimeAvailable
+          && isKnownDeclarationLiteralFormula(formulaText)
           && ("token-ast".equals(declarationRuntime) || "embedded-bridge".equals(declarationRuntime))) {
         declarationRuntime = "generated-ast";
       }

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
@@ -545,6 +545,16 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
 
   @Override
   protected Object evalBooleanFactorExpr(BooleanFactorExpr node) {
+    // The generated mapper has no @mapping recursion into NotExpression, so a
+    // top-level "not(...)" boolean factor is mis-mapped: the outer "not" is
+    // dropped and node.value() holds only the inner operand (as raw text for
+    // "not(false)", or as a ComparisonExpr node for "not(1>2)"). Detect this via
+    // the node's source snippet and re-parse the whole factor as a NotExpr so the
+    // negation is honoured. (issue #25)
+    Optional<Boolean> negated = tryEvaluateNotFactor(node);
+    if (negated.isPresent()) {
+      return negated.get();
+    }
     Object value = node.value();
     if (value instanceof ComparisonExpr comp) {
       return eval(comp);
@@ -575,6 +585,61 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
       return bool;
     }
     return toBoolean(value);
+  }
+
+  /**
+   * If this boolean factor's source snippet is a top-level {@code not(...)}
+   * expression, re-parse it as a {@link NotExpr} and evaluate. The generated
+   * mapper drops the outer negation (see {@link #evalBooleanFactorExpr}), so this
+   * source-snippet-driven re-parse restores correct semantics. Returns empty when
+   * the factor is not a negation or cannot be re-parsed. (issue #25)
+   */
+  private Optional<Boolean> tryEvaluateNotFactor(BooleanFactorExpr node) {
+    Optional<String> snippet = sourceSnippetOfNode(node).map(String::strip);
+    if (snippet.isEmpty()) {
+      return Optional.empty();
+    }
+    String candidate = snippet.get();
+    if (!isTopLevelNotExpression(candidate)) {
+      return Optional.empty();
+    }
+    SpecifiedExpressionTypes booleanTypes =
+        new SpecifiedExpressionTypes(ExpressionTypes._boolean, numberType);
+    try {
+      String parseSource = P4PreferredAstMapper.normalizeExpressionSnippetForParsing(candidate);
+      // Request the NotExpr node directly. The default mapper would otherwise wrap
+      // the formula back into BooleanOrExpr → BooleanFactorExpr, re-entering this
+      // same branch (infinite recursion).
+      TinyExpressionP4AST ast = P4PreferredAstMapper.parseByAstSimpleName(parseSource, "NotExpr");
+      if (!(ast instanceof NotExpr)) {
+        return Optional.empty();
+      }
+      Object result = new P4TypedAstEvaluator(
+          booleanTypes, context, parseSource, effectiveLookupFormulaSource(), classLoader).eval(ast);
+      return result == null ? Optional.empty() : Optional.of(Boolean.TRUE.equals(toBoolean(result)));
+    } catch (RuntimeException ignored) {
+      return Optional.empty();
+    }
+  }
+
+  /** True if {@code text} is exactly a top-level {@code not( ... )} expression. */
+  private static boolean isTopLevelNotExpression(String text) {
+    if (text == null) {
+      return false;
+    }
+    String normalized = text.strip();
+    if (!normalized.startsWith("not")) {
+      return false;
+    }
+    int i = 3;
+    while (i < normalized.length() && Character.isWhitespace(normalized.charAt(i))) {
+      i++;
+    }
+    if (i >= normalized.length() || normalized.charAt(i) != '(') {
+      return false;
+    }
+    int close = GeneratedP4ValueAstEvaluator.findMatching(normalized, i, '(', ')');
+    return close == normalized.length() - 1;
   }
 
   // =========================================================================

--- a/src/main/java/org/unlaxer/tinyexpression/p4/P4PreferredAstMapper.java
+++ b/src/main/java/org/unlaxer/tinyexpression/p4/P4PreferredAstMapper.java
@@ -956,26 +956,7 @@ public final class P4PreferredAstMapper {
 
   private static TinyExpressionP4AST parseViaMapperCompat(
       String source, String preferredAstSimpleName, long deadlineNanos) {
-    ParseContext context = new ParseContext(createRootSourceCompat(source));
-    ScopeStore.registerDispatcher(context);
-    if (deadlineNanos > 0L) {
-      registerDeadlineListener(context, deadlineNanos);
-    }
-    Parsed parsed;
-    try {
-      Parser rootParser = TinyExpressionP4Parsers.getRootParser();
-      parsed = rootParser.parse(context);
-    } finally {
-      closeParseContextQuietly(context);
-    }
-    if (!parsed.isSucceeded()) {
-      throw new IllegalArgumentException("Parse failed: " + source);
-    }
-    int consumed = consumedLengthCompat(parsed.getConsumed());
-    if (consumed != source.length()) {
-      throw new IllegalArgumentException("Parse failed at offset " + consumed + ": " + source);
-    }
-    Token rootToken = parsed.getRootToken(true);
+    Token rootToken = parseRootToken(source, deadlineNanos);
     clearMapperSourceSpans();
     Token bestMappedToken = invokeFindBestMappedToken(rootToken, preferredAstSimpleName);
     TinyExpressionP4AST mapped = invokeMapToken(bestMappedToken);
@@ -983,6 +964,69 @@ public final class P4PreferredAstMapper {
       throw new IllegalArgumentException("No mapped node found in parse tree");
     }
     return mapped;
+  }
+
+  /**
+   * Parses {@code source} fully and returns the root token.
+   *
+   * <p>The grammar's top-level {@code Expression} rule tries {@code NumberExpression}
+   * before {@code BooleanExpression} so that arithmetic such as {@code $a+$b} is fully
+   * consumed (a BooleanExpression-first ordering would consume only {@code $a}). The
+   * generated combinator {@code Choice} is PEG first-match and never backtracks into a
+   * later alternative once an earlier one commits, so for a bare top-level boolean
+   * comparison such as {@code 1 > 0 & 2 > 1} the {@code NumberExpression} alternative
+   * matches only the leading {@code 1} and the root {@code Formula} rule then fails at
+   * EOF (issue #23).
+   *
+   * <p>Reordering the grammar alternatives cannot fix both cases under PEG, and adding a
+   * comparison-anchored top-level alternative roughly doubles parse time for
+   * {@code if(...comparison...)} formulas (the comparison's number operand re-parses the
+   * whole {@code if} block before failing). So the fix is applied here instead: when the
+   * standard {@code Formula} parse fails or under-consumes, retry once treating
+   * {@code BooleanExpression} as the root. This adds cost only for inputs the standard
+   * parse already rejected, leaving the hot path untouched.
+   */
+  private static Token parseRootToken(String source, long deadlineNanos) {
+    ParseResult primary = parseWithRoot(TinyExpressionP4Parsers.getRootParser(), source, deadlineNanos);
+    if (primary.fullyConsumed(source)) {
+      return primary.rootToken();
+    }
+    // issue #23 fallback: a bare top-level boolean comparison is shadowed by the
+    // NumberExpression-first top-level dispatch. Retry with BooleanExpression as root.
+    ParseResult booleanRoot = parseWithRoot(
+        Parser.get(TinyExpressionP4Parsers.BooleanExpressionParser.class), source, deadlineNanos);
+    if (booleanRoot.fullyConsumed(source)) {
+      return booleanRoot.rootToken();
+    }
+    if (!primary.succeeded()) {
+      throw new IllegalArgumentException("Parse failed: " + source);
+    }
+    throw new IllegalArgumentException("Parse failed at offset " + primary.consumed() + ": " + source);
+  }
+
+  private static ParseResult parseWithRoot(Parser rootParser, String source, long deadlineNanos) {
+    ParseContext context = new ParseContext(createRootSourceCompat(source));
+    ScopeStore.registerDispatcher(context);
+    if (deadlineNanos > 0L) {
+      registerDeadlineListener(context, deadlineNanos);
+    }
+    Parsed parsed;
+    try {
+      parsed = rootParser.parse(context);
+    } finally {
+      closeParseContextQuietly(context);
+    }
+    if (!parsed.isSucceeded()) {
+      return new ParseResult(false, -1, null);
+    }
+    int consumed = consumedLengthCompat(parsed.getConsumed());
+    return new ParseResult(true, consumed, parsed.getRootToken(true));
+  }
+
+  private record ParseResult(boolean succeeded, int consumed, Token rootToken) {
+    boolean fullyConsumed(String source) {
+      return succeeded && consumed == source.length();
+    }
   }
 
   /**


### PR DESCRIPTION
並列エージェント（worktree分離）で調査・修正した P4 インタプリタの3バグ。各々対象テストで検証済（公開 unlaxer 3.0.4、forkCount=1）。

## #23 bare boolean 比較がパース失敗
`1 > 0 & 2 > 1` 等が top-level でパース不能（P4 の Choice は PEG 先頭一致でバックトラックせず、Expression が NumberExpression を `1` だけで確定→EOF失敗）。修正: `P4PreferredAstMapper` で Formula ルートを先に試し、**失敗/未消費時のみ BooleanExpression ルートで1回リトライ**（ホットパス不変・コードのみ）。

## #25 standalone `not(...)` が常に false
top-level `not(...)` を _boolean 評価すると false（生成マッパーが外側 NotExpr を脱落）。`evalBooleanFactorExpr` がソーススニペットから top-level not を検出し NotExpr として再パース。if内 not は元から正常。

## #30 runtime タグの誤表示
`AstEvaluatorCalculator` が宣言リテラル式の runtime タグを無条件で "generated-ast" に書換え（結果は正しいがタグが嘘）。`generatedAstRuntimeAvailable` を確認してから書換えるよう gate。

## 検証
P4TypedAstEvaluatorTest(47)・AstEvaluatorGeneratedValuePathTest(15)・AstEvaluatorTokenLiteralFallbackTest 回帰なし。フル失敗群は origin/master でも同一（#27/#29/#30-1=環境/別issue）。

Closes #23 #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)