### PR TITLE
chore: unlaxer-dsl 3.0.6 採用 (#43 heterogeneous @value codegen fix; #32)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-common</artifactId>
-			<version>3.0.5</version>
+			<version>3.0.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-dsl</artifactId>
-			<version>3.0.5</version>
+			<version>3.0.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains</groupId>


### PR DESCRIPTION
3.0.6 は透過的 choice の `@value`(BooleanComparable)を実 AST ノードへ解決（ソース文字列化を解消）。生成 `BooleanFactorExpr.value` が InExpr/IsPresentExpr 等を保持し、`if(...)` 条件内の `.in()`/`isPresent`/dot-predicate boolean 因子が AST 忠実に。

効果は現状 latent（if-source shadow が先に走るため）。shadow 無効化計測で条件失敗が **12→6**。baseline ゲート緑。

関連: unlaxer-parser#45, #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)