### PR TITLE
chore: adopt unlaxer-dsl 3.0.7 — StringConcat/BooleanEquality operand widening (#32)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-common</artifactId>
-			<version>3.0.6</version>
+			<version>3.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-dsl</artifactId>
-			<version>3.0.6</version>
+			<version>3.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains</groupId>

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
@@ -381,7 +381,7 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
   protected Object evalStringConcatExpr(StringConcatExpr node) {
     String leftStr = resolveStringLeaf(node.left());
     List<String> ops = node.op();
-    List<String> rights = node.right();
+    List<Object> rights = node.right();
     if (ops == null || ops.isEmpty()) {
       return leftStr;
     }
@@ -1991,6 +1991,21 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
     return false;
   }
 
+
+  /**
+   * BooleanComparable は透過 mapped choice のため、operand は実 AST ノード（Object）または
+   * source テキスト（String）として届く。ノードなら直接 eval（AST 経路に忠実）、
+   * それ以外は従来の source-snippet 経路にフォールバックする。(tinyexpression #32)
+   */
+  private boolean resolveBooleanSourceOperand(Object operand) {
+    if (operand instanceof TinyExpressionP4AST ast) {
+      return Boolean.TRUE.equals(toBoolean(eval(ast)));
+    }
+    if (operand instanceof String text) {
+      return resolveBooleanSourceOperand(text);
+    }
+    return operand != null && Boolean.TRUE.equals(toBoolean(operand));
+  }
 
   private boolean resolveBooleanSourceOperand(String rawSource) {
     String normalized = rawSource == null ? "" : rawSource.strip();

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/P4DefaultJavaCodeEmitter.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/P4DefaultJavaCodeEmitter.java
@@ -212,6 +212,17 @@ public class P4DefaultJavaCodeEmitter extends TinyExpressionP4Evaluator<String> 
     };
   }
 
+  /**
+   * BooleanComparable は透過 mapped choice のため operand は実 AST ノード（Object）または
+   * source テキスト（String）として届く。ノードなら直接コード生成、それ以外は従来の
+   * source-snippet 経路にフォールバックする。(tinyexpression #32)
+   */
+  private String renderBooleanOperandSource(Object operand) {
+    if (operand instanceof TinyExpressionP4AST ast) return eval(ast);
+    if (operand instanceof String text) return renderBooleanOperandSource(text);
+    return "false";
+  }
+
   private String renderBooleanOperandSource(String rawSource) {
     String normalized = rawSource == null ? "" : rawSource.strip();
     if (normalized.isEmpty()) {
@@ -254,7 +265,7 @@ public class P4DefaultJavaCodeEmitter extends TinyExpressionP4Evaluator<String> 
   protected String evalStringConcatExpr(StringConcatExpr node) {
     String leftExpr = renderStringLeaf(node.left());
     List<String> ops = node.op();
-    List<String> rights = node.right();
+    List<Object> rights = node.right();
     if (ops == null || ops.isEmpty()) return leftExpr;
     StringBuilder sb = new StringBuilder("(String.valueOf(").append(leftExpr).append(")");
     int count = Math.min(ops.size(), rights.size());

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/P4TypedJavaCodeEmitter.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/P4TypedJavaCodeEmitter.java
@@ -228,7 +228,7 @@ public class P4TypedJavaCodeEmitter extends TinyExpressionP4Evaluator<String> {
   protected String evalStringConcatExpr(StringConcatExpr node) {
     String leftExpr = renderStringLeaf(node.left());
     List<String> ops = node.op();
-    List<String> rights = node.right();
+    List<Object> rights = node.right();
     if (ops == null || ops.isEmpty()) {
       return leftExpr;
     }
@@ -374,6 +374,21 @@ public class P4TypedJavaCodeEmitter extends TinyExpressionP4Evaluator<String> {
       case "!=" -> "!(" + left + ").equals(" + right + ")";
       default -> "false";
     };
+  }
+
+  /**
+   * BooleanComparable は透過 mapped choice のため operand は実 AST ノード（Object）または
+   * source テキスト（String）として届く。ノードなら直接コード生成、それ以外は従来の
+   * source-snippet 経路にフォールバックする。(tinyexpression #32)
+   */
+  private String renderBooleanOperandSource(Object operand) {
+    if (operand instanceof TinyExpressionP4AST ast) {
+      return eval(ast);
+    }
+    if (operand instanceof String text) {
+      return renderBooleanOperandSource(text);
+    }
+    return "false";
   }
 
   private String renderBooleanOperandSource(String rawSource) {


### PR DESCRIPTION
## 概要

unlaxer-dsl **3.0.7**（parser PR #46）を採用。透過 mapped choice を operand に持つ assoc fold が operand を `Object` と推論し、`mapTransparentValue` で実 AST ノードへ解決するようになった。これにより `StringConcatExpr.right` が `List<Object>`、`BooleanEqualityExpr.left/right` が `Object` になる。

## 変更点
- `pom.xml`: unlaxer-common / unlaxer-dsl を 3.0.7 に。
- `P4TypedAstEvaluator` / `P4TypedJavaCodeEmitter` / `P4DefaultJavaCodeEmitter`:
  - `evalStringConcatExpr`: `node.right()` を `List<Object>` で受ける（`resolveStringLeaf(Object)` / `renderStringLeaf(Object)` は既存）。
  - `BooleanEqualityExpr`: `resolveBooleanSourceOperand` / `renderBooleanOperandSource` に `Object` オーバーロードを追加。実 AST ノードは直接 eval、それ以外（source テキスト）は従来の source-snippet 経路へフォールバック。**if-source shadow は外していない。**

string concat / boolean-equality の operand が source 再パースでなく AST 経路で忠実に評価される。

## 検証
- `mvn verify`: 630 tests、新規失敗ゼロ（既知の #38 ternary 二重カッコのみ）。`check-test-baseline.sh` ゲート OK。
- release 3.0.7 に対して `mvn compile` 成功。

注: Central→repo1 同期ラグ（~15-60分）で CI が一時赤になる場合あり。同期後に rerun。

🤖 Generated with [Claude Code](https://claude.com/claude-code)