### PR TITLE
chore: adopt unlaxer-dsl 3.0.8 (level-bounded capture + identifier wrapper; #32)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-common</artifactId>
-			<version>3.0.7</version>
+			<version>3.0.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-dsl</artifactId>
-			<version>3.0.7</version>
+			<version>3.0.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains</groupId>


### PR DESCRIPTION
unlaxer-dsl **3.0.8**（parser PR #47）を採用。生成マッパーの AST 経路忠実度を改善：
- **構造位置ベース capture 解決**（`findCapturedToken`）：if 分岐・slice index のグローバル索引誤カウントを是正。
- **identifier トークンのラッパー参照**：`VariableRefExpr.name` / import `@alias`・`@method` が空になる問題を是正。

consumer コード変更なし（純 codegen 改善・AST フィールド型不変）。pom のみ 3.0.8 に。

## 検証
- `mvn compile`（release 3.0.8）成功。
- baseline ゲート緑（新規失敗ゼロ、既知 #38 のみ）。
- if-source shadow OFF の calc 失敗：4 → 2（testMin/testMax 解消）。残り testStringSlice（ネスト slice value）/ testTypeInference（var宣言）は別タスク。

注: Central→repo1 同期ラグで CI 一時赤の可能性（同期後 rerun）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)