### PR TITLE
chore: adopt unlaxer-dsl 3.0.9 (nested-slice multi-rule dispatch; #32)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-common</artifactId>
-			<version>3.0.8</version>
+			<version>3.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.unlaxer</groupId>
 			<artifactId>unlaxer-dsl</artifactId>
-			<version>3.0.8</version>
+			<version>3.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains</groupId>


### PR DESCRIPTION
unlaxer-dsl **3.0.9**（parser PR #48）採用。ネスト slice の value 解決を AST 経路で完成（多ルール plain dispatch + bounded capture fallback）。consumer 変更なし（純 codegen・AST 型不変）。pom のみ 3.0.9 に。

## 検証
- `mvn compile`（release 3.0.9）成功。
- baseline ゲート緑（新規失敗ゼロ、既知 #38 のみ）。
- if-source shadow OFF の calc 失敗：2 → 1（testStringSlice/testMin/testMax 解消、残り testTypeInference=var宣言のみ）。

注: Central→repo1 同期ラグで CI 一時赤の可能性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)