### PR TITLE
fix: declared-type-aware AST equality for var declarations (#32 "C")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to TinyExpression are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- `P4TypedAstEvaluator`: declared variable types (`var $name as string …`) now make `$name == $other` a **string** comparison on the pure-AST path, instead of coercing both operands to boolean. Variable declarations carry `@declares` (not `@mapping`) so they are dropped from the generated AST; declared types are now threaded from `AstDeclarationRuntime` into the evaluator (mirrors the legacy `VariableTypeResolver`). Resolves the last pure-AST (if-source-shadow OFF) failure in `testTypeInference`. Consumer-only change — no unlaxer-dsl/codegen release. (#32 / handoff #44 "C")
+
 ## [1.4.11] - 2026-04-21
 
 ### Fixed

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstDeclarationRuntime.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstDeclarationRuntime.java
@@ -1,5 +1,7 @@
 package org.unlaxer.tinyexpression.evaluator.ast;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,9 +73,11 @@ final class AstDeclarationRuntime {
       // Use a scoped context to avoid leaking variable declarations to the caller's context.
       CalculationContext scopedContext = createScopedContext(calculationContext);
 
+      Map<String, ExpressionType> declaredVariableTypes = new LinkedHashMap<>();
       for (Token declarationToken : tinyExpressionTokens.getVariableDeclarationTokens()) {
         applyDeclaration(
             declarationToken, specifiedExpressionTypes, scopedContext, classLoader, methodDeclarationsSource, source);
+        recordDeclaredType(declarationToken, declaredVariableTypes);
       }
       String expressionSource = tokenTextCompat(tinyExpressionTokens.getExpressionToken());
       String rawExpressionSource = methodDeclarationsSource.isBlank()
@@ -93,7 +97,7 @@ final class AstDeclarationRuntime {
           : specifiedExpressionTypes.resultType();
       return evaluateExpressionWithMode(
           expressionSource, resultType, specifiedExpressionTypes, scopedContext, classLoader,
-          methodDeclarationsSource)
+          methodDeclarationsSource, declaredVariableTypes)
           .map(result -> new MainExpressionEvaluation(result.value(), result.runtime()));
     } catch (Throwable ignored) {
       return Optional.empty();
@@ -169,8 +173,26 @@ final class AstDeclarationRuntime {
       SpecifiedExpressionTypes specifiedExpressionTypes, CalculationContext calculationContext, ClassLoader classLoader,
       String methodDeclarationsSource) {
     return evaluateExpressionWithMode(
-        expressionSource, resultType, specifiedExpressionTypes, calculationContext, classLoader, methodDeclarationsSource)
+        expressionSource, resultType, specifiedExpressionTypes, calculationContext, classLoader, methodDeclarationsSource,
+        Map.of())
         .map(EvalResult::value);
+  }
+
+  /**
+   * Collect the declared type of a {@code var}/{@code variable} declaration token so the pure-AST
+   * evaluator can type-check comparisons against declared variables (declaration tokens carry no
+   * {@code @mapping}, so they never reach the generated AST). (#32 / handoff #44 "C")
+   */
+  private static void recordDeclaredType(Token declarationToken, Map<String, ExpressionType> target) {
+    try {
+      VariableInfo variableInfo = VariableDeclarationParser.extractVariableInfo(declarationToken);
+      if (variableInfo != null && variableInfo.name != null && !variableInfo.name.isEmpty()
+          && variableInfo.expressionType != null) {
+        target.put(variableInfo.name, variableInfo.expressionType);
+      }
+    } catch (Throwable ignored) {
+      // A declaration we cannot type-resolve simply gets no declared-type hint.
+    }
   }
 
   private record EvalResult(Object value, String runtime) {}
@@ -178,7 +200,7 @@ final class AstDeclarationRuntime {
   private static Optional<EvalResult> evaluateExpressionWithMode(
       String expressionSource, ExpressionType resultType,
       SpecifiedExpressionTypes specifiedExpressionTypes, CalculationContext calculationContext, ClassLoader classLoader,
-      String methodDeclarationsSource) {
+      String methodDeclarationsSource, Map<String, ExpressionType> declaredVariableTypes) {
     String embeddedFormulaSource = joinExpressionWithMethods(expressionSource, methodDeclarationsSource);
     SpecifiedExpressionTypes evalTypes =
         new SpecifiedExpressionTypes(resultType, resolveNumberType(specifiedExpressionTypes, resultType));
@@ -196,7 +218,7 @@ final class AstDeclarationRuntime {
           if (mapped.get() instanceof TinyExpressionP4AST typedAst) {
             try {
               Object p4Result = new P4TypedAstEvaluator(
-                  evalTypes, calculationContext, expressionSource, classLoader).eval(typedAst);
+                  evalTypes, calculationContext, expressionSource, classLoader, declaredVariableTypes).eval(typedAst);
               if (p4Result != null) {
                 return Optional.of(new EvalResult(p4Result, "p4-typed"));
               }

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
@@ -38,6 +38,14 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
   private final String sourceFormula;
   private final String lookupFormulaSource;
   private final ClassLoader classLoader;
+  /**
+   * Declared variable types collected from {@code var}/{@code variable} declarations in the
+   * preamble (e.g. {@code var $name as string ...}). The generated P4 AST drops declaration
+   * tokens (they carry {@code @declares}, not {@code @mapping}), so this map is the only way the
+   * pure-AST path learns that a bare {@code $name} should compare as a string rather than a number.
+   * Empty when the formula has no declarations. (#32 / handoff #44 "C")
+   */
+  private final Map<String, ExpressionType> declaredVariableTypes;
 
   public P4TypedAstEvaluator(SpecifiedExpressionTypes types, CalculationContext context) {
     this(types, context, null, null);
@@ -49,7 +57,18 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
   }
 
   public P4TypedAstEvaluator(SpecifiedExpressionTypes types, CalculationContext context,
+      String sourceFormula, ClassLoader classLoader, Map<String, ExpressionType> declaredVariableTypes) {
+    this(types, context, sourceFormula, sourceFormula, classLoader, declaredVariableTypes);
+  }
+
+  public P4TypedAstEvaluator(SpecifiedExpressionTypes types, CalculationContext context,
       String sourceFormula, String lookupFormulaSource, ClassLoader classLoader) {
+    this(types, context, sourceFormula, lookupFormulaSource, classLoader, Map.of());
+  }
+
+  public P4TypedAstEvaluator(SpecifiedExpressionTypes types, CalculationContext context,
+      String sourceFormula, String lookupFormulaSource, ClassLoader classLoader,
+      Map<String, ExpressionType> declaredVariableTypes) {
     this.resultType = types.resultType() != null ? types.resultType() : ExpressionTypes.object;
     this.numberType = resolveNumberType(types);
     this.context = context;
@@ -57,6 +76,7 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
     this.sourceFormula = sourceFormula;
     this.lookupFormulaSource = lookupFormulaSource;
     this.classLoader = classLoader;
+    this.declaredVariableTypes = declaredVariableTypes == null ? Map.of() : declaredVariableTypes;
   }
 
   private static ExpressionType resolveNumberType(SpecifiedExpressionTypes types) {
@@ -1647,14 +1667,71 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
 
   @Override
   protected Object evalBooleanEqualityExpr(BooleanEqualityExpr node) {
+    String op = node.op() == null ? "==" : node.op().strip();
+    // A declared-string operand (e.g. `var $name as string ...`) forces string equality on the
+    // pure-AST path. The grammar maps `$a == $b` to BooleanEqualityExpr regardless of declared
+    // type (declarations are dropped from the AST), so without this the operands would be coerced
+    // to boolean — the legacy/source path consults the same declared type. (#32 / handoff #44 "C")
+    if (isDeclaredStringEquality(node.left(), node.right())) {
+      String left = stringValueOfEqualityOperand(node.left());
+      String right = stringValueOfEqualityOperand(node.right());
+      return switch (op) {
+        case "==" -> left.equals(right);
+        case "!=" -> !left.equals(right);
+        default -> false;
+      };
+    }
     boolean left = resolveBooleanSourceOperand(node.left());
     boolean right = resolveBooleanSourceOperand(node.right());
-    String op = node.op() == null ? "==" : node.op().strip();
     return switch (op) {
       case "==" -> left == right;
       case "!=" -> left != right;
       default -> false;
     };
+  }
+
+  /**
+   * True when either operand is a bare variable reference declared as {@code string} in the
+   * preamble. Mirrors the legacy {@code VariableTypeResolver}, which makes a comparison string-typed
+   * when a declared-string variable participates.
+   */
+  private boolean isDeclaredStringEquality(Object left, Object right) {
+    return isDeclaredStringOperand(left) || isDeclaredStringOperand(right);
+  }
+
+  private boolean isDeclaredStringOperand(Object operand) {
+    if (declaredVariableTypes.isEmpty()) {
+      return false;
+    }
+    String varName = equalityOperandVariableName(operand);
+    if (varName == null) {
+      return false;
+    }
+    ExpressionType declared = declaredVariableTypes.get(varName);
+    return declared != null && declared.isString();
+  }
+
+  private String equalityOperandVariableName(Object operand) {
+    if (operand instanceof VariableRefExpr varRef) {
+      return resolveVariableRefName(varRef);
+    }
+    if (operand instanceof BinaryExpr binaryExpr) {
+      return extractExactVariableReference(binaryExpr);
+    }
+    return null;
+  }
+
+  private String stringValueOfEqualityOperand(Object operand) {
+    if (operand instanceof VariableRefExpr varRef) {
+      String varName = resolveVariableRefName(varRef);
+      Object resolved = varName == null ? null : resolveVariableAny(varName);
+      return resolved == null ? "" : String.valueOf(resolved);
+    }
+    if (operand instanceof TinyExpressionP4AST ast) {
+      Object resolved = eval(ast);
+      return resolved == null ? "" : String.valueOf(resolved);
+    }
+    return operand == null ? "" : String.valueOf(operand);
   }
 
   // =========================================================================

--- a/src/test/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluatorDeclaredTypeTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluatorDeclaredTypeTest.java
@@ -1,0 +1,59 @@
+package org.unlaxer.tinyexpression.evaluator.ast;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.RoundingMode;
+import java.util.Map;
+
+import org.junit.Test;
+import org.unlaxer.tinyexpression.CalculationContext;
+import org.unlaxer.tinyexpression.CalculationContext.Angle;
+import org.unlaxer.tinyexpression.ConcurrentCalculationContext;
+import org.unlaxer.tinyexpression.evaluator.javacode.SpecifiedExpressionTypes;
+import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST.BooleanEqualityExpr;
+import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST.VariableRefExpr;
+import org.unlaxer.tinyexpression.parser.ExpressionType;
+import org.unlaxer.tinyexpression.parser.ExpressionTypes;
+
+/**
+ * Direct, shadow-independent coverage of declared-type-aware equality on the pure-AST path
+ * (#32 / handoff #44 "C"). The if-source shadow rescues if-conditions at runtime, so this test
+ * exercises {@code evalBooleanEqualityExpr} directly to lock in the behavior regardless of the
+ * shadow (which is gated for removal on the parse-performance work, #38).
+ */
+public class P4TypedAstEvaluatorDeclaredTypeTest {
+
+  private CalculationContext context() {
+    CalculationContext context = new ConcurrentCalculationContext(2, RoundingMode.HALF_UP, Angle.DEGREE);
+    context.set("name", "opa");
+    context.set("remitterAccountHolderKana", "opai");
+    return context;
+  }
+
+  private Object evalEquality(Map<String, ExpressionType> declaredTypes) {
+    P4TypedAstEvaluator evaluator = new P4TypedAstEvaluator(
+        new SpecifiedExpressionTypes(ExpressionTypes._boolean, ExpressionTypes._float),
+        context(), null, null, declaredTypes);
+    BooleanEqualityExpr node =
+        new BooleanEqualityExpr(new VariableRefExpr("name"), "==", new VariableRefExpr("remitterAccountHolderKana"));
+    return evaluator.eval(node);
+  }
+
+  /**
+   * With {@code var $name as string}, "opa" == "opai" must be a STRING comparison → false.
+   * (Previously the operands were coerced to boolean → false == false → true.)
+   */
+  @Test
+  public void declaredStringVariableForcesStringEquality() {
+    assertEquals(false, evalEquality(Map.of("name", ExpressionTypes.string)));
+  }
+
+  /**
+   * Without a declared type, behavior is unchanged: operands coerce to boolean
+   * (number/string == is the legacy default), so two non-boolean values compare equal.
+   */
+  @Test
+  public void undeclaredVariablesKeepBooleanEqualityBehavior() {
+    assertEquals(true, evalEquality(Map.of()));
+  }
+}


### PR DESCRIPTION
## 背景（handoff #44 の残り "C"）

P4 fallback=0（#32）に向けた純AST経路忠実度サイクルの最後の if-source-shadow OFF 失敗 = `testTypeInference` block 1:

```
var $name as string set if not exists 'opa' description='名前だよ！';
if($name == $remitterAccountHolderKana){1}else{0}
```
（ctx: `$name` 未設定, `$remitter='opai'`。期待 `0`）

## 根本原因（精査済み）

- var 宣言は `@declares` のみ（`@mapping` 無し）→ 生成 P4 AST から**脱落**。純AST経路は `$name` が string 宣言だと知り得ない。
- AST 上 `$name == $remitterAccountHolderKana` は `BooleanEqualityExpr` にマップされ、`evalBooleanEqualityExpr` が**両オペランドを無条件で boolean に強制**していた → 文字列比較になるべき所が `false == false → true` で誤って `1` を返していた。
- if-source shadow ON（baseline）では source 経路が宣言型を解決するため隠れていた失敗。

## 修正（consumer-only / codegen・リリース不要）

legacy `VariableTypeResolver` と同等に、宣言プリアンブルの宣言型を評価器へ配線:

1. **`P4TypedAstEvaluator`**: `declaredVariableTypes:Map<String,ExpressionType>` を追加（constructor 経由）。**宣言なし式では空 map → 既存挙動と完全一致**。equality のオペランドが `as string` 宣言の変数参照なら**文字列比較**に分岐。
2. **`AstDeclarationRuntime.tryEvaluateMainExpression`**: 宣言トークン（`VariableDeclarationParser.extractVariableInfo`）から型 map を構築し、主式を評価する `P4TypedAstEvaluator` に渡す。

## 検証

- 一時 if-off トグル（`-Dp4.disableIfSourceShadow`）で `testTypeInference` が**純AST経路で PASS**（最後の if-off 失敗が解消）→ トグルは revert 済み。
- `testTypeInference` if-ON（baseline）が P4/legacy 両 calculator で PASS。
- **フル baseline gate 緑**（`OK: 新規失敗なし`、既知失敗は #38 の 1 件のみ）。BUILD SUCCESS。
- 恒久回帰テスト `P4TypedAstEvaluatorDeclaredTypeTest` 追加（shadow 非依存に `evalBooleanEqualityExpr` を直接検証、2件 PASS）。

## 残（このPRの範囲外）

if-shadow の実除去は別途**パース性能（#38 / unlaxer-parser #40 packrat）**が前提。本PRは純AST経路の宣言型忠実度を確立するもので、production の if-ON 挙動は不変。

関連: #32, #35, #22, #38。前 handoff #44。

🤖 Generated with [Claude Code](https://claude.com/claude-code)