### PR TITLE
feat(p4): packrat memoization ON by default — parity corpus fallback 3→0

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/p4/P4PreferredAstMapper.java
+++ b/src/main/java/org/unlaxer/tinyexpression/p4/P4PreferredAstMapper.java
@@ -1004,14 +1004,26 @@ public final class P4PreferredAstMapper {
     throw new IllegalArgumentException("Parse failed at offset " + primary.consumed() + ": " + source);
   }
 
+  /**
+   * Packrat memoization is ON by default (see {@link #parseWithRoot}); opt out with
+   * {@code -Dtinyexpression.p4.memoize=false}.
+   */
+  private static boolean memoizeEnabled() {
+    return false == "false".equalsIgnoreCase(System.getProperty("tinyexpression.p4.memoize", "true"));
+  }
+
   private static ParseResult parseWithRoot(Parser rootParser, String source, long deadlineNanos) {
     ParseContext context = new ParseContext(createRootSourceCompat(source));
     ScopeStore.registerDispatcher(context);
-    // Opt-in packrat memoization (unlaxer-parser #40): collapses the exponential backtracking that
-    // deeply nested fraud-detection formulas trigger (#19/#38). Off by default — enable with
-    // -Dtinyexpression.p4.memoize=true. Safe with the @scopeTree/@declares/@backref grammar because
-    // memoization excludes TransactionListener-bearing sub-trees (scope effects are never skipped).
-    if (Boolean.getBoolean("tinyexpression.p4.memoize")) {
+    // Packrat memoization (unlaxer-parser #40): collapses the exponential backtracking that deeply
+    // nested fraud-detection formulas trigger (#19/#38). ON by default now that it is proven fast and
+    // parse-equivalent (parity verified in #40) and that the mapping phase no longer re-maps subtrees
+    // (tinyexpression #49) — together these let formulas that previously blew the parse deadline (e.g.
+    // toUpperCase('..')[4:6].in(..), the giant nested-if fraud formulas) reach the P4 path instead of
+    // falling back to the legacy parser. Opt OUT with -Dtinyexpression.p4.memoize=false. Safe with the
+    // @scopeTree/@declares/@backref grammar because memoization excludes TransactionListener-bearing
+    // sub-trees (scope effects are never skipped).
+    if (memoizeEnabled()) {
       context.enableMemoize();
     }
     if (deadlineNanos > 0L) {

--- a/test-baseline.txt
+++ b/test-baseline.txt
@@ -1,1 +1,0 @@
-org.unlaxer.tinyexpression.evaluator.ast.TernaryExpressionTest#testTernaryInSinWithDoubleParensStillWorks


### PR DESCRIPTION
## 背景（fallback=0）

#40 packrat parse メモ化が parse-equivalent と実証され、#49 で mapping 段の再マッピングも解消した今、parity corpus が legacy にフォールバックする唯一の残因は **10s parse deadline 超過**（memoize が opt-in/OFF だったため）でした。実測でフォールバックしていた3式:

```
if((1>0|10<20)&(true)){10}else{0}                         -> token-ast
if(not(toUpperCase('cnjpuszn')[4:6].in(...))){1}else{0}   -> deadline -> legacy
if(not(not(... 同上 ...))){1}else{0}                       -> deadline -> legacy
```

memoize ON で3式とも高速 parse → **p4-typed 経路で正答**（10.0 / 0.0 / 1.0）。

## 変更
`P4PreferredAstMapper` の memoize を**既定 ON**化（`-Dtinyexpression.p4.memoize=false` で opt-out）。

## 効果
- `ThreeExecutionBackendExtractedCorpusParityTest`: legacy フォールバック **3→0**、所要 100s→19s。
- `P4AstEvaluatorCalculatorTest`（#38/#20 巨大ネスト if）: **~1263s→~167s**。
- フルスイート 633 tests 緑。既知 baseline 失敗 `TernaryExpressionTest#testTernaryInSinWithDoubleParensStillWorks` も解消 → `test-baseline.txt` を空に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)