### PR TITLE
feat(p4): friendly parse-error messages (position + caret + curated expected)

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
@@ -13,6 +13,7 @@ import org.unlaxer.Parsed;
 import org.unlaxer.StringSource;
 import org.unlaxer.Token;
 import org.unlaxer.compiler.InstanceAndByteCode;
+import org.unlaxer.context.DiagnosticFormatter;
 import org.unlaxer.context.ParseContext;
 import org.unlaxer.parser.ParseException;
 import org.unlaxer.parser.Parser;
@@ -815,11 +816,12 @@ public class AstEvaluatorCalculator implements Calculator {
       }
     }
     Parser parser = getParser();
-    ParseContext parseContext = new ParseContext(StringSource.createRootSource(formula));
+    StringSource rootSource = StringSource.createRootSource(formula);
+    ParseContext parseContext = new ParseContext(rootSource);
     try (parseContext) {
       Parsed parsed = parser.parse(parseContext);
       if (!parsed.isSucceeded()) {
-        throw new ParseException("failed to parse:" + formula);
+        throw new ParseException(parseFailureMessage(rootSource, parseContext, formula));
       }
       parsed.getRootToken(true);
     } catch (ParseException e) {
@@ -827,6 +829,23 @@ public class AstEvaluatorCalculator implements Calculator {
     } catch (Exception e) {
       throw new ParseException("failed to parse:" + formula, e);
     }
+  }
+
+  /**
+   * Build a human-readable parse-failure message (line/column + caret + expected tokens) from the
+   * parser's farthest-failure diagnostics. Falls back to the terse {@code "failed to parse:"} form
+   * if diagnostics are unavailable or throw — a diagnostics problem must never mask the parse error.
+   */
+  private static String parseFailureMessage(StringSource rootSource, ParseContext parseContext, String formula) {
+    try {
+      String formatted = DiagnosticFormatter.format(rootSource, parseContext.getParseFailureDiagnostics());
+      if (formatted != null && !formatted.isBlank()) {
+        return formatted;
+      }
+    } catch (Throwable ignored) {
+      // diagnostics best-effort only
+    }
+    return "failed to parse:" + formula;
   }
 
   private Optional<TinyExpressionP4AST.MethodInvocationExpr> syntheticMethodInvocationAst(String formula) {

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
@@ -14,6 +14,7 @@ import org.unlaxer.StringSource;
 import org.unlaxer.Token;
 import org.unlaxer.compiler.InstanceAndByteCode;
 import org.unlaxer.context.DiagnosticFormatter;
+import org.unlaxer.context.ParseFailureDiagnostics;
 import org.unlaxer.context.ParseContext;
 import org.unlaxer.parser.ParseException;
 import org.unlaxer.parser.Parser;
@@ -838,14 +839,69 @@ public class AstEvaluatorCalculator implements Calculator {
    */
   private static String parseFailureMessage(StringSource rootSource, ParseContext parseContext, String formula) {
     try {
-      String formatted = DiagnosticFormatter.format(rootSource, parseContext.getParseFailureDiagnostics());
-      if (formatted != null && !formatted.isBlank()) {
-        return formatted;
+      ParseFailureDiagnostics diagnostics = parseContext.getParseFailureDiagnostics();
+      if (diagnostics != null) {
+        // Build a user-facing "expected" list from literal tokens / display hints only — never the
+        // internal parser class names (DigitParser, WordParser, Chain…) that the default formatter
+        // appends as "(in …)". Showing class names is the "RPAREN problem": correct, but unkind.
+        java.util.LinkedHashSet<String> expected = new java.util.LinkedHashSet<>();
+        for (String token : diagnostics.getExpectedTokens()) {
+          addExpectedHint(expected, token);
+        }
+        if (expected.isEmpty()) {
+          for (ParseFailureDiagnostics.ExpectedHintCandidate hint : diagnostics.getExpectedHintCandidates()) {
+            addExpectedHint(expected, hint.getDisplayHint());
+          }
+        }
+        String message;
+        if (expected.isEmpty()) {
+          message = "ここで、式が読めなくなりました";
+        } else {
+          // The grammar legitimately allows many next tokens at an operand position, so cap the
+          // enumeration — a wall of 40 tokens is its own kind of unkindness. Curating these into
+          // grammar-level human hints is a separate effort (the kind of work this engine deserves).
+          List<String> shown = new ArrayList<>(expected);
+          boolean truncated = shown.size() > 8;
+          String list = String.join("  ", shown.subList(0, Math.min(8, shown.size())));
+          message = "ここで、式が読めなくなりました。来られるのは例えば: " + list + (truncated ? "  …" : "");
+        }
+        String formatted = DiagnosticFormatter.format(rootSource, diagnostics.getFarthestOffset(), message);
+        if (formatted != null && !formatted.isBlank()) {
+          return formatted;
+        }
       }
     } catch (Throwable ignored) {
       // diagnostics best-effort only
     }
     return "failed to parse:" + formula;
+  }
+
+  /** Keep only short, user-facing literals/keywords; drop blanks, comment/whitespace tokens, and
+   *  internal parser/combinator class names (DigitParser, Chain, OneOrMore…). */
+  private static final java.util.Set<String> EXPECTED_HINT_DENYLIST = java.util.Set.of(
+      "//", "/*", "*/",                                                         // comment markers
+      "Chain", "Choice", "OneOrMore", "ZeroOrMore", "Optional", "NonOrdered",   // combinators
+      "LazyChain", "LazyChoice",
+      "number", "string", "boolean", "object", "float",                         // type keywords (noise
+      "Number", "String", "Boolean", "Object", "Float");                        // at most error sites)
+
+  private static void addExpectedHint(java.util.Set<String> sink, String hint) {
+    if (hint == null) {
+      return;
+    }
+    String trimmed = hint.strip();
+    if (trimmed.isEmpty() || trimmed.length() > 16) {
+      return;
+    }
+    // getExpectedTokens() quotes literals ('+', ' ', '//'); classify on the unquoted inner text.
+    String inner = trimmed;
+    if (inner.length() >= 2 && inner.startsWith("'") && inner.endsWith("'")) {
+      inner = inner.substring(1, inner.length() - 1);
+    }
+    if (inner.isBlank() || inner.endsWith("Parser") || EXPECTED_HINT_DENYLIST.contains(inner)) {
+      return; // whitespace token, internal parser name, combinator, or type-keyword noise
+    }
+    sink.add(trimmed);
   }
 
   private Optional<TinyExpressionP4AST.MethodInvocationExpr> syntheticMethodInvocationAst(String formula) {


### PR DESCRIPTION
## 背景
これまで構文エラーは全て `failed to parse:<formula>` の一行（位置も理由もなし）。物語 #53 の「優しさ」テーマにも逆行していた。

## 変更（`AstEvaluatorCalculator`）
`validateFormulaParseable` のパース失敗時に、`ParseContext.getParseFailureDiagnostics()` を `DiagnosticFormatter` で整形:
- **行:列＋キャレット**で失敗位置を指し示す
- 「来られるのは例えば: …」を**リテラル/表示ヒントのみ**から構築。内部 parser/combinator 名（`DigitParser`/`Chain`/`OneOrMore`…）・コメント記号・空白・型キーワードのノイズを除去し、**8件で打ち切り**（"RPAREN問題"＝正しいが不親切、を回避）

例:
```
if(1>0){1}  →  ^ 来られるのは例えば: 'else'
1>0?10:20   →  col2 ^ '-' '+' ')' '(' …
```
失敗経路のメッセージのみ変更（旧文字列を assert するテストなし）。文法レベルの完全な人間向けヒントは follow-up。

## 検証
フルスイート 633 tests 0-fail、baseline ゲート exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)