### PR TITLE
feat(p4): accept bare-variable match case values (universal fallback=0)

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/p4/P4StrictMatchTypingValidator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/p4/P4StrictMatchTypingValidator.java
@@ -170,10 +170,16 @@ public final class P4StrictMatchTypingValidator {
     Matcher variableMatcher = BARE_VARIABLE_PATTERN.matcher(normalized);
     if (variableMatcher.matches()) {
       String actualHint = variableMatcher.group(1);
-      if (!expectedType.accepts(actualHint)) {
+      // A bare variable WITHOUT an inline type hint is fine: the generated P4 grammar parses it into
+      // the match family chosen by the result type, and P4TypedAstEvaluator resolves the variable to
+      // the correct value (verified for number/string/boolean — e.g. match{1==1->$val,default->0}
+      // with $val=7 yields 7 on the p4-typed path). Rejecting it only forced a needless legacy
+      // fallback. We still reject an EXPLICIT, mismatched hint (e.g. `$x as string` in a number
+      // match) — that is a genuine type error. (universal fallback=0)
+      if (actualHint != null && !expectedType.accepts(actualHint)) {
         return Optional.of(new Violation(
             "P4 strict match typing rejected direct "
-                + expectedType.label + " case value: " + normalized,
+                + expectedType.label + " case value with mismatched type hint: " + normalized,
             startOffset,
             endOffset,
             ViolationKind.DIRECT_VARIABLE_CASE_VALUE,

--- a/src/test/java/org/unlaxer/tinyexpression/p4/P4BackendParityTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/p4/P4BackendParityTest.java
@@ -322,32 +322,51 @@ public class P4BackendParityTest {
   }
 
   @Test
-  public void testP4ExactParseRejectsAmbiguousDirectMatchVariableWithoutHint() {
+  public void testP4HandlesDirectMatchVariableWithoutHint() {
+    // A bare variable case value (no inline type hint) used to be rejected by the strict-match
+    // typing validator and forced onto the legacy parser. The generated P4 grammar parses it into
+    // the result-type's match family and P4TypedAstEvaluator resolves it correctly, so it now runs
+    // on the p4-typed path (universal fallback=0). An explicit MISMATCHED hint is still rejected
+    // (see testP4RejectsDirectMatchVariableWithMismatchedHint).
     String formula = "match{1==1->$val,default->0}";
     SpecifiedExpressionTypes types =
         new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
 
     Calculator javaCode = CalculatorCreatorRegistry.javaCodeCreator()
-        .create(new Source(formula), "MatchStrictRef_jc", types, cl);
+        .create(new Source(formula), "MatchVarRef_jc", types, cl);
     Calculator p4Ast = CalculatorCreatorRegistry.p4AstEvaluatorCreator()
-        .create(new Source(formula), "MatchStrictRef_p4ast", types, cl);
+        .create(new Source(formula), "MatchVarRef_p4ast", types, cl);
 
-    assertEquals(Boolean.FALSE, p4Ast.getObject("_tinyP4ParserUsed", Boolean.class));
-    assertEquals(Boolean.FALSE, p4Ast.getObject("_tinyP4ParserExact", Boolean.class));
-    assertEquals("semantic", p4Ast.getObject("_tinyP4ParserProbeMode", String.class));
+    assertEquals(Boolean.TRUE, p4Ast.getObject("_tinyP4ParserUsed", Boolean.class));
 
     CalculationContext ctx = CalculationContext.newConcurrentContext();
     ctx.set("val", 10f);
     float ref = floatValue(javaCode.apply(ctx));
     float actual = floatValue(p4Ast.apply(ctx));
-    assertEquals("semantic rejection should still preserve legacy result", ref, actual, 0.001f);
-    assertFalse("strict-typing rejection should avoid p4-typed runtime",
-        "p4-typed".equals(p4Ast.getObject("_astEvaluatorRuntime", String.class)));
-    String fallbackReason = p4Ast.getObject("_p4FallbackReason", String.class);
-    assertNotNull("semantic rejection should preserve fallback reason", fallbackReason);
-    assertTrue("semantic rejection should skip cross-check mismatch fallback",
-        fallbackReason.contains("P4 strict match typing rejected"));
+    assertEquals("bare-variable match must agree with the legacy result", ref, actual, 0.001f);
+    assertEquals("bare-variable match should now run on the p4-typed path",
+        "p4-typed", p4Ast.getObject("_astEvaluatorRuntime", String.class));
+  }
+
+  @Test
+  public void testP4RejectsDirectMatchVariableWithMismatchedHint() {
+    // An EXPLICIT type hint that disagrees with the match's result type is a genuine type error:
+    // `$val as string` cannot be a number case value, so the formula does not parse at all (the
+    // mismatch is caught at parse time, not silently accepted). Relaxing the bare-variable guard
+    // does not open this door.
+    String formula = "match{1==1->$val as string,default->0}";
+    SpecifiedExpressionTypes types =
+        new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    boolean rejected = false;
+    try {
+      CalculatorCreatorRegistry.p4AstEvaluatorCreator()
+          .create(new Source(formula), "MatchVarMismatch_p4ast", types, cl);
+    } catch (RuntimeException expected) {
+      rejected = true;
+    }
+    assertTrue("a mismatched explicit type hint must not be silently accepted", rejected);
   }
 
   @Test
@@ -368,19 +387,29 @@ public class P4BackendParityTest {
   }
 
   @Test
-  public void testP4ExactParseRejectsParenthesizedDirectMatchVariableWithoutHint() {
+  public void testP4HandlesParenthesizedDirectMatchVariableWithoutHint() {
+    // Parenthesized bare variable case value — same as the unparenthesized case, now handled on the
+    // p4-typed path instead of being rejected onto the legacy parser. (universal fallback=0)
     String formula = "match{1==1->($val),default->0}";
     SpecifiedExpressionTypes types =
         new SpecifiedExpressionTypes(ExpressionTypes._float, ExpressionTypes._float);
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
 
+    Calculator javaCode = CalculatorCreatorRegistry.javaCodeCreator()
+        .create(new Source(formula), "MatchParen_jc", types, cl);
     Calculator p4Ast = CalculatorCreatorRegistry.p4AstEvaluatorCreator()
-        .create(new Source(formula), "MatchStrictParen_p4ast", types, cl);
+        .create(new Source(formula), "MatchParen_p4ast", types, cl);
 
-    assertEquals(Boolean.FALSE, p4Ast.getObject("_tinyP4ParserUsed", Boolean.class));
-    assertEquals(Boolean.FALSE, p4Ast.getObject("_tinyP4ParserExact", Boolean.class));
-    assertEquals("semantic", p4Ast.getObject("_tinyP4ParserProbeMode", String.class));
+    assertEquals(Boolean.TRUE, p4Ast.getObject("_tinyP4ParserUsed", Boolean.class));
     assertEquals("NumberMatchExpr", p4Ast.getObject("_tinyP4AstNodeType", String.class));
+
+    CalculationContext ctx = CalculationContext.newConcurrentContext();
+    ctx.set("val", 10f);
+    float ref = floatValue(javaCode.apply(ctx));
+    assertEquals("parenthesized bare-variable match must agree with the legacy result",
+        ref, floatValue(p4Ast.apply(ctx)), 0.001f);
+    assertEquals("should run on the p4-typed path",
+        "p4-typed", p4Ast.getObject("_astEvaluatorRuntime", String.class));
   }
 
   @Test


### PR DESCRIPTION
## 背景（universal fallback=0）
`match{1==1->$val,default->0}`（型ヒント無しの bare 変数 case 値）は `P4StrictMatchTypingValidator` に拒否され legacy にフォールバックしていた。

**実測で「陳腐化した過剰防御」と確定**:
- 生成 P4 文法は bare 変数 match を結果型の族（NumberMatchExpr 等）として**正しくパース**
- `P4TypedAstEvaluator` は変数を**正しく解決**（$val=7→7、string/boolean も同様）
- validator だけ無効化しても token-ast のままだったのは、validator の fast-fail が**動く P4 経路を先に潰していた**ため

## 変更（tinyexpression のみ・文法/生成器/再公開 不要）
- validator: **bare（ヒント無し）変数は受理**。明示的型ミスマッチ（`$val as string` を number match）は引き続き拒否＝そもそも parse 失敗で捕捉。メソッド呼びガードは不変。
- テスト: `…RejectsAmbiguous/Parenthesized…WithoutHint` 2件を「p4-typed で正答」に更新＋ミスマッチ拒否テスト追加。メソッド呼び拒否テストは不変。

## 効果
`match{...->$var,...}` が legacy フォールバックでなく **p4-typed** で評価。フルスイート 634 tests 0-fail、baseline ゲート exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)