### PR TITLE
refactor(p4): drop ternary-arg source shadow + clear cosmetic declaration fallback flag

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/AstEvaluatorCalculator.java
@@ -437,6 +437,14 @@ public class AstEvaluatorCalculator implements Calculator {
         declarationRuntime = "generated-ast";
       }
       setObject("_astEvaluatorRuntime", declarationRuntime);
+      // Declarations are gated out of the PRIMARY path (the generated P4 AST has no declaration root),
+      // so a speculative "declaration-aware fallback" reason was set above. But AstDeclarationRuntime
+      // actually evaluated this on a P4 path — so when the runtime is p4-typed/generated-ast, clear the
+      // misleading fallback markers. The result is not a fallback; the markers should say so. (cosmetic)
+      if ("p4-typed".equals(declarationRuntime) || "generated-ast".equals(declarationRuntime)) {
+        removeObject("_p4FallbackReason");
+        removeObject("_p4FallbackFormula");
+      }
       return declarationEvaluated.get().value();
     }
 
@@ -732,6 +740,14 @@ public class AstEvaluatorCalculator implements Calculator {
 
   @Override
   public void after(CalculationContext calculationContext) {
+  }
+
+  private void removeObject(String key) {
+    objectByKey.remove(key);
+    JavaCodeCalculatorV3 local = delegate;
+    if (local != null) {
+      local.setObject(key, null);
+    }
   }
 
   @Override

--- a/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
+++ b/src/main/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluator.java
@@ -17,7 +17,6 @@ import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST.*;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4Evaluator;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4Mapper;
 import org.unlaxer.tinyexpression.p4.P4PreferredAstMapper;
-import org.unlaxer.tinyexpression.p4.P4TernarySourceSupport;
 import org.unlaxer.tinyexpression.parser.ExpressionType;
 import org.unlaxer.tinyexpression.parser.ExpressionTypes;
 
@@ -1026,17 +1025,7 @@ public class P4TypedAstEvaluator extends TinyExpressionP4Evaluator<Object> {
         }
       }
     }
-    Optional<P4TernarySourceSupport.TernaryParts> ternaryParts =
-        P4TernarySourceSupport.parseTopLevelTernary(argExpr);
-    if (ternaryParts.isPresent()) {
-      Optional<Boolean> conditionValue = evaluateArgumentCondition(ternaryParts.get().conditionSource());
-      if (conditionValue.isPresent()) {
-        boolean selected = Boolean.TRUE.equals(conditionValue.get());
-        return evaluateArgumentExpression(
-            selected ? ternaryParts.get().thenSource() : ternaryParts.get().elseSource(),
-            parameterType);
-      }
-    }
+    // [EXPERIMENT] ternary-arg source shadow removed; general P4 parse below handles it
     if (P4PreferredAstMapper.preferredAstSimpleNames(argExpr, parameterType).contains("IfExpr")) {
       Optional<Object> direct = AstEmbeddedExpressionRuntime.tryEvaluateFormulaDirect(
           argExpr, parameterType, argumentTypes, context, classLoader);


### PR DESCRIPTION
p4-typed 経路を「正直・char-scan フリー」に近づける2点の整理。

## 1. ternary-arg source shadow 除去
引数文脈の ternary を `P4TernarySourceSupport.parseTopLevelTernary`（charAt/深さスキャナ）で再パースしていた箇所を削除。直下の汎用 P4 parse+eval が ternary 引数を処理する（ternary→IfExpr、if-source shadow 撤去済みで純 AST 評価が忠実）。検証: `abs(1<0?-3:3)=3`, `pow(2,1>0?3:1)=8` は p4-typed のまま。未使用 import も削除。

## 2. 宣言式の cosmetic フォールバックフラグ整理
宣言式は `AstDeclarationRuntime` 経由で p4-typed 評価されるのに、gate 前に立てた `_p4FallbackReason="declaration-aware fallback…"` が残り、正しい p4-typed 結果が fallback に見えていた。runtime が p4-typed/generated-ast のとき当該フラグをクリア。結果: `var …; expr` → `runtime=p4-typed, reason=null`。

## 検証
フルスイート 634 tests 0-fail、baseline ゲート exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)