### PR TITLE
refactor(p4): delete dead slice source char-scanner

### DIFF
--- a/src/main/java/org/unlaxer/tinyexpression/p4/P4SliceSourceSupport.java
+++ b/src/main/java/org/unlaxer/tinyexpression/p4/P4SliceSourceSupport.java
@@ -1,17 +1,19 @@
 package org.unlaxer.tinyexpression.p4;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
+/**
+ * Source-span extraction for a mapped P4 AST node.
+ *
+ * <p>Historically this class also re-parsed slice syntax from the source text with a hand-written
+ * char/bracket scanner ({@code parseSliceSnippet} and friends). That char-scanning shadow is gone:
+ * slice indices are read directly from the {@code SliceExpr} AST now (grammar disambiguates
+ * {@code [start:end:step]} into typed index rules — tinyexpression #35). All that remains is
+ * {@link #sourceSnippetOfNode}, a reflection-based helper that returns the original substring a node
+ * spans (used only as a defensive variable-name recovery fallback in the Java-code emitters).
+ */
 public final class P4SliceSourceSupport {
-
-  public record SliceParts(
-      String valueSource,
-      String startSource,
-      String endSource,
-      String stepSource) {}
 
   private P4SliceSourceSupport() {}
 
@@ -40,154 +42,5 @@ public final class P4SliceSourceSupport {
     } catch (Throwable ignored) {
       return Optional.empty();
     }
-  }
-
-  public static Optional<SliceParts> slicePartsOfNode(Object node, String sourceFormula) {
-    return sourceSnippetOfNode(node, sourceFormula).flatMap(P4SliceSourceSupport::parseSliceSnippet);
-  }
-
-  public static Optional<SliceParts> parseSliceSnippet(String sliceSource) {
-    if (sliceSource == null) {
-      return Optional.empty();
-    }
-    String source = sliceSource.strip();
-    if (source.isEmpty()) {
-      return Optional.empty();
-    }
-    int openBracket = findTopLevelSliceOpenBracket(source);
-    if (openBracket < 0) {
-      return Optional.empty();
-    }
-    int closeBracket = findMatchingBracket(source, openBracket);
-    if (closeBracket < 0 || closeBracket != source.length() - 1) {
-      return Optional.empty();
-    }
-    String valueSource = source.substring(0, openBracket).strip();
-    if (valueSource.isEmpty()) {
-      return Optional.empty();
-    }
-    List<String> parts = splitTopLevel(source.substring(openBracket + 1, closeBracket), ':');
-    if (parts.size() < 2 || parts.size() > 3) {
-      return Optional.empty();
-    }
-    String startSource = normalizeComponent(parts.get(0));
-    String endSource = normalizeComponent(parts.get(1));
-    String stepSource = parts.size() == 3 ? normalizeComponent(parts.get(2)) : null;
-    return Optional.of(new SliceParts(valueSource, startSource, endSource, stepSource));
-  }
-
-  private static String normalizeComponent(String component) {
-    if (component == null) {
-      return null;
-    }
-    String normalized = component.strip();
-    return normalized.isEmpty() ? null : normalized;
-  }
-
-  private static int findTopLevelSliceOpenBracket(String source) {
-    int parenDepth = 0;
-    int braceDepth = 0;
-    int bracketDepth = 0;
-    boolean inSingleQuote = false;
-    boolean inDoubleQuote = false;
-    for (int i = 0; i < source.length(); i++) {
-      char c = source.charAt(i);
-      char prev = i > 0 ? source.charAt(i - 1) : '\0';
-      if (c == '\'' && !inDoubleQuote && prev != '\\') {
-        inSingleQuote = !inSingleQuote;
-        continue;
-      }
-      if (c == '"' && !inSingleQuote && prev != '\\') {
-        inDoubleQuote = !inDoubleQuote;
-        continue;
-      }
-      if (inSingleQuote || inDoubleQuote) {
-        continue;
-      }
-      switch (c) {
-        case '(' -> parenDepth++;
-        case ')' -> parenDepth = Math.max(0, parenDepth - 1);
-        case '{' -> braceDepth++;
-        case '}' -> braceDepth = Math.max(0, braceDepth - 1);
-        case '[' -> {
-          if (parenDepth == 0 && braceDepth == 0 && bracketDepth == 0) {
-            return i;
-          }
-          bracketDepth++;
-        }
-        case ']' -> bracketDepth = Math.max(0, bracketDepth - 1);
-        default -> {
-        }
-      }
-    }
-    return -1;
-  }
-
-  private static int findMatchingBracket(String source, int openIndex) {
-    int bracketDepth = 0;
-    boolean inSingleQuote = false;
-    boolean inDoubleQuote = false;
-    for (int i = openIndex; i < source.length(); i++) {
-      char c = source.charAt(i);
-      char prev = i > 0 ? source.charAt(i - 1) : '\0';
-      if (c == '\'' && !inDoubleQuote && prev != '\\') {
-        inSingleQuote = !inSingleQuote;
-        continue;
-      }
-      if (c == '"' && !inSingleQuote && prev != '\\') {
-        inDoubleQuote = !inDoubleQuote;
-        continue;
-      }
-      if (inSingleQuote || inDoubleQuote) {
-        continue;
-      }
-      if (c == '[') {
-        bracketDepth++;
-      } else if (c == ']') {
-        bracketDepth--;
-        if (bracketDepth == 0) {
-          return i;
-        }
-      }
-    }
-    return -1;
-  }
-
-  private static List<String> splitTopLevel(String text, char separator) {
-    ArrayList<String> parts = new ArrayList<>();
-    int start = 0;
-    int parenDepth = 0;
-    int braceDepth = 0;
-    int bracketDepth = 0;
-    boolean inSingleQuote = false;
-    boolean inDoubleQuote = false;
-    for (int i = 0; i < text.length(); i++) {
-      char c = text.charAt(i);
-      char prev = i > 0 ? text.charAt(i - 1) : '\0';
-      if (c == '\'' && !inDoubleQuote && prev != '\\') {
-        inSingleQuote = !inSingleQuote;
-      } else if (c == '"' && !inSingleQuote && prev != '\\') {
-        inDoubleQuote = !inDoubleQuote;
-      }
-      if (inSingleQuote || inDoubleQuote) {
-        continue;
-      }
-      switch (c) {
-        case '(' -> parenDepth++;
-        case ')' -> parenDepth = Math.max(0, parenDepth - 1);
-        case '{' -> braceDepth++;
-        case '}' -> braceDepth = Math.max(0, braceDepth - 1);
-        case '[' -> bracketDepth++;
-        case ']' -> bracketDepth = Math.max(0, bracketDepth - 1);
-        default -> {
-        }
-      }
-      if (parenDepth == 0 && braceDepth == 0 && bracketDepth == 0 && c == separator) {
-        parts.add(text.substring(start, i));
-        start = i + 1;
-      }
-    }
-    parts.add(text.substring(start));
-    return parts;
   }
 }

--- a/src/test/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluatorTest.java
+++ b/src/test/java/org/unlaxer/tinyexpression/evaluator/ast/P4TypedAstEvaluatorTest.java
@@ -14,7 +14,6 @@ import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4AST.*;
 import org.unlaxer.tinyexpression.generated.p4.TinyExpressionP4Mapper;
 import org.unlaxer.tinyexpression.p4.P4PreferredAstMapper;
-import org.unlaxer.tinyexpression.p4.P4SliceSourceSupport;
 import org.unlaxer.tinyexpression.parser.ExpressionTypes;
 
 public class P4TypedAstEvaluatorTest {
@@ -460,28 +459,21 @@ public class P4TypedAstEvaluatorTest {
   }
 
   @Test
-  public void testSliceSourcePartsOfNode() {
-    TinyExpressionP4AST ast = P4PreferredAstMapper.parseDetailed(
-        "'gateman'[::-1]",
-        ExpressionTypes.string).ast();
-    assertTrue(ast instanceof SliceExpr);
-    P4SliceSourceSupport.SliceParts parts =
-        P4SliceSourceSupport.slicePartsOfNode(ast, "'gateman'[::-1]").orElseThrow();
-    assertEquals("'gateman'", parts.valueSource());
-    assertNull(parts.startSource());
-    assertNull(parts.endSource());
-    assertEquals("-1", parts.stepSource());
+  public void testSliceReverseAndStepOnAstPath() {
+    // The slice indices come from the SliceExpr AST (start/end/step), not from re-parsing the source
+    // text — so assert the actual evaluated result on the pure AST path. (former source-shadow test)
+    P4TypedAstEvaluator evaluator = new P4TypedAstEvaluator(
+        new SpecifiedExpressionTypes(ExpressionTypes.string, ExpressionTypes._float), newContext());
 
-    TinyExpressionP4AST steppedAst = P4PreferredAstMapper.parseDetailed(
-        "'1a2b3'[::2]",
-        ExpressionTypes.string).ast();
-    assertTrue(steppedAst instanceof SliceExpr);
-    P4SliceSourceSupport.SliceParts steppedParts =
-        P4SliceSourceSupport.slicePartsOfNode(steppedAst, "'1a2b3'[::2]").orElseThrow();
-    assertEquals("'1a2b3'", steppedParts.valueSource());
-    assertNull(steppedParts.startSource());
-    assertNull(steppedParts.endSource());
-    assertEquals("2", steppedParts.stepSource());
+    TinyExpressionP4AST reverse = P4PreferredAstMapper.parseDetailed(
+        "'gateman'[::-1]", ExpressionTypes.string).ast();
+    assertTrue(reverse instanceof SliceExpr);
+    assertEquals("nametag", evaluator.eval(reverse));
+
+    TinyExpressionP4AST stepped = P4PreferredAstMapper.parseDetailed(
+        "'1a2b3'[::2]", ExpressionTypes.string).ast();
+    assertTrue(stepped instanceof SliceExpr);
+    assertEquals("123", evaluator.eval(stepped));
   }
 
   // ── NumberMatchExpr ──


### PR DESCRIPTION
## 背景（charAt shadow 撤去）
`P4SliceSourceSupport` の `parseSliceSnippet`/`slicePartsOfNode`/`findTopLevelSliceOpenBracket`/`findMatchingBracket`/`splitTopLevel`（＋`SliceParts`）は、`value[start:end:step]` をソース文字列から手書きで char/bracket 走査する shadow。**slice インデックスが SliceExpr の AST から得られるようになった #35 以降、呼び出し元はゼロ**（完全死蔵）。

## 変更
死蔵チェーンを丸ごと削除。`sourceSnippetOfNode`（reflection ベースの span 抽出。emitter の変数名回復に防御的使用）のみ残置。死蔵スキャナを直接検査していた `testSliceSourcePartsOfNode` は、実 AST 経路の結果検査に書き換え（`'gateman'[::-1]`→"nametag"、`'1a2b3'[::2]`→"123"）。

## 検証
フルスイート 634 tests 0-fail、baseline ゲート exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)