### PR TITLE
docs: backend-coverage-matrix に JAVA_CODE_LEGACY_ASTCREATOR を追加 (5→6 backends)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,14 +25,14 @@
 
 | # | Document | Description |
 |---|----------|-------------|
-| 1 | [Implementation Guide](./implementation-guide-dialogue.en.md) | Learn the 5 backends through dialogue between Senior and Newcomer |
+| 1 | [Implementation Guide](./implementation-guide-dialogue.en.md) | Learn the 6 backends through dialogue between Senior and Newcomer |
 | 2 | [Parser Generator Comparison & @eval Strategy](./parser-generator-comparison-and-eval-strategy.en.md) | unlaxer vs ANTLR/PEG.js/Tree-sitter comparison and @eval annotation design |
 
 ## Analysis
 
 | Document | Description |
 |----------|-------------|
-| [backend-coverage-matrix.md](./backend-coverage-matrix.md) | Backend coverage matrix for the 5 execution backends |
+| [backend-coverage-matrix.md](./backend-coverage-matrix.md) | Backend coverage matrix for the 6 execution backends |
 | [feature-parity-diff.md](./feature-parity-diff.md) | Feature parity diff between hand-written path and UBNF (P4) path |
 
 ## Other Documentation

--- a/docs/backend-coverage-matrix.md
+++ b/docs/backend-coverage-matrix.md
@@ -1,10 +1,11 @@
 # Backend Coverage Matrix
 
-## 5 Execution Backends
+## 6 Execution Backends
 
 | Backend | 実装クラス | 主要用途 |
 |---------|-----------|---------|
 | compile-hand | JavaCodeCalculatorV3 | 本番 (10^9 tx/month) |
+| compile-legacy-astcreator | LegacyAstCreatorJavaCodeCalculator | 凍結（リグレッション比較用）。JavaCodeCalculatorV3 を継承し tokenReduer() のみ override |
 | P4-typed | P4TypedAstEvaluator | DAP, LSP (sealed switch) |
 | P4-reflection | GeneratedP4ValueAstEvaluator | レガシー (reflection) |
 | ast-hand | AstNumberExpressionEvaluator | リテラル演算のみ |
@@ -12,30 +13,32 @@
 
 ## Feature Coverage
 
-| 機能 | compile-hand | P4-typed | P4-reflection | ast-hand | compile-dsl |
-|------|:-----------:|:--------:|:-------------:|:--------:|:-----------:|
-| 四則演算 (+,-,*,/) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 変数参照 ($var) | ✅ | ✅ | ✅ | ❌ | ✅ |
-| 比較演算 (==,<,>) | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Boolean演算 (&,\|,^) | ✅ | ✅ | ✅ | ❌ | ✅ |
-| if/else | ✅ | ✅ | ✅ | ❌ | ✅ |
-| ternary (cond?a:b) | ✅ | ✅ | ✅ | ❌ | ✅ |
-| match/case | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Math 14関数 | ✅ | ✅ | ❌ | ❌ | ❌ |
-| min/max 可変引数 | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Not演算子 | ✅ | ✅ | ❌ | ❌ | ❌ |
-| toNum() | ✅ | ✅ | ❌ | ❌ | ❌ |
-| String methods (関数形式) | ✅ | ✅ | ❌ | ❌ | ❌ |
-| String methods (ドット形式) | ✅ | ✅ | ❌ | ❌ | ❌ |
-| String predicates | ✅ | ✅ | ❌ | ❌ | ❌ |
-| isPresent() | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **MethodInvocation (call)** | ✅ | ✅ | ✅ | ❌ | ✅ |
-| **External呼び出し** | ✅ | ✅ | ✅ | ❌ | ✅ |
-| **Side effect** | ✅ | ✅ | **❌** | ❌ | ✅ |
-| 変数宣言 (var) | ✅ | 部分的 | ✅ | ❌ | ✅ |
-| String連結 (+) | ✅ | ✅ | ❌ | ❌ | ✅ |
-| String slice ($s[0:3]) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| inTimeRange/inDayTimeRange | ✅ | ✅ | ❌ | ❌ | ✅ |
+| 機能 | compile-hand | compile-legacy-astcreator | P4-typed | P4-reflection | ast-hand | compile-dsl |
+|------|:-----------:|:------------------------:|:--------:|:-------------:|:--------:|:-----------:|
+| 四則演算 (+,-,*,/) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 変数参照 ($var) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| 比較演算 (==,<,>) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Boolean演算 (&,\|,^) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| if/else | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| ternary (cond?a:b) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| match/case | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Math 14関数 | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| min/max 可変引数 | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Not演算子 | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| toNum() | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| String methods (関数形式) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| String methods (ドット形式) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| String predicates | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| isPresent() | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **MethodInvocation (call)** | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| **External呼び出し** | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| **Side effect** | ✅ | ✅ | ✅ | **❌** | ❌ | ✅ |
+| 変数宣言 (var) | ✅ | ✅ | 部分的 | ✅ | ❌ | ✅ |
+| String連結 (+) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| String slice ($s[0:3]) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| inTimeRange/inDayTimeRange | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+
+> **注**: `compile-legacy-astcreator` は `JavaCodeCalculatorV3` を継承し `tokenReduer()` のみを override する（`LegacyAstCreatorJavaCodeCalculator:15-33`）。Java コード生成能力は `compile-hand` と等価のため、Feature Coverage は `compile-hand` と同一。SPEC.md 1.3 に準拠（ステータス: 凍結・リグレッション比較用）。
 
 ## Fallback Chain
 


### PR DESCRIPTION
## 対象 issue

Closes #60

## 変更概要

`spec/SPEC.md` 1.3 は 6 バックエンド（`JAVA_CODE_LEGACY_ASTCREATOR` 含む）を記載するが、`docs/backend-coverage-matrix.md` は 5 バックエンド表記で `JAVA_CODE_LEGACY_ASTCREATOR` が欠落していた。本 PR で両者の整合を取る。

## 変更内容

- `docs/backend-coverage-matrix.md`
  - 冒頭見出し \`## 5 Execution Backends\` → \`## 6 Execution Backends\`
  - バックエンド一覧表に \`compile-legacy-astcreator\` 行を追加（実装クラス: \`LegacyAstCreatorJavaCodeCalculator\`、凍結・リグレッション比較用）
  - Feature Coverage 表に \`compile-legacy-astcreator\` 列を追加
  - 根拠注記を追加（\`LegacyAstCreatorJavaCodeCalculator\` は \`JavaCodeCalculatorV3\` を継承し \`tokenReduer()\` のみ override するため、Java コード生成能力は \`compile-hand\` と等価）
- \`docs/INDEX.md\`
  - \"Learn the 5 backends\" → \"Learn the 6 backends\"
  - \"Backend coverage matrix for the 5 execution backends\" → \"... 6 execution backends\"

## coverage 判定の根拠（実測）

\`LegacyAstCreatorJavaCodeCalculator\` は \`JavaCodeCalculatorV3\` を継承し \`tokenReduer()\` のみを override する（\`src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/legacy/LegacyAstCreatorJavaCodeCalculator.java:15-33\`）。Java コード生成能力は \`compile-hand\` と等価なため、Feature Coverage は \`compile-hand\` と同一。

String slice (\`$s[0:3]\`) についても、\`StringClauseBuilder.buildSlice\`（\`src/main/java/org/unlaxer/tinyexpression/evaluator/javacode/StringClauseBuilder.java:178\`）が \`SliceParser\` に register されており、\`compile-hand\` と同じ経路で処理されるため ✅ とした。

## 影響範囲

- docs のみ（コード変更なし、ビルド不要）

## 検証

- markdown 表の列数整合（6 列揃い）を確認
- SPEC.md 1.3 とバックエンド数が一致することを確認

## 関連

- 元監査レポート (2026-08-01) MEDIUM severity #4