### PR TITLE
docs: SPEC.md/specs の依存バージョンと UBNF 行数・参照パスを更新 (#59)

### DIFF
--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -121,7 +121,7 @@ graph TB
 
 #### P4 パーサー（UBNF 自動生成）
 
-`tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf`（321 行）から `unlaxer-dsl` により生成される。
+`tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf`（589 行）から `unlaxer-dsl` により生成される。
 
 | 生成物 | 役割 |
 |--------|------|
@@ -1582,8 +1582,8 @@ export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens java.
 
 | グループ ID | アーティファクト ID | バージョン | 用途 |
 |------------|-------------------|----------|------|
-| `org.unlaxer` | `unlaxer-common` | **3.0.2** | パーサーコンビネータランタイム（レガシーパーサーのベース） |
-| `org.unlaxer` | `unlaxer-dsl` | **3.0.2** | UBNF 文法からのパーサー自動生成（P4 スタック） |
+| `org.unlaxer` | `unlaxer-common` | **3.0.11** | パーサーコンビネータランタイム（レガシーパーサーのベース） |
+| `org.unlaxer` | `unlaxer-dsl` | **3.0.11** | UBNF 文法からのパーサー自動生成（P4 スタック） |
 | `org.jetbrains` | `annotations` | `24.0.1` | `@NotNull` 等のアノテーション |
 | `net.arnx` | `jsonic` | `1.3.10` | JSON シリアライゼーション |
 
@@ -1608,6 +1608,7 @@ unlaxer-common はレガシーパーサースタックのランタイムライ�
 
 - v1.4.10: unlaxer-common 2.8.0 対応（`NoneChildCollectingParser` 移行）
 - v1.4.11 / 9b166fc: unlaxer-common/dsl **3.0.2** に移行（`StringSource` API 対応 + `validateWithWarnings`）
+- v1.4.x（#49/#50/#51）: unlaxer-common/dsl **3.0.11** に更新（`mapToken` メモ化・反射除去・packrat メモ化 default 有効化）
 
 ### 9.4 unlaxer-dsl との関係
 
@@ -1625,8 +1626,12 @@ unlaxer-dsl は P4 パーサースタックの生成ツールである。
 
 | ファイル | 行数 | 説明 |
 |---------|------|------|
-| `tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf` | 321 行 | 拡張版（アクティブ） |
-| `docs/ubnf/tinyexpression-p4-draft.ubnf` | 239 行 | 初期ドラフト |
+| `tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf` | 589 行 | **権威**（ビルドが使用・生成元） |
+| `docs/ubnf/tinyexpression-p4-draft.ubnf` | 239 行 | 初期ドラフト（参照用・生成には使用しない） |
+| `docs/ubnf/tinyexpression-p4-complete.ubnf` | 548 行 | 中間スナップショット（参照用・生成には使用しない） |
+| `docs/ubnf/tinyexpression-p4-assoc-repro.ubnf` | 24 行 | 結合性再現用の最小再現セット（参照用・生成には使用しない） |
+
+> **注意**: ビルド（`mvn compile` の generate-sources フェーズ）が実際に読み込むのは `tools/.../grammar/tinyexpression-p4.ubnf` のみ。`docs/ubnf/` 配下の 3 ファイルは歴史的参照用で、生成パイプラインには関与しない。整理（削除含む）は別 issue で人間判断予定。
 
 **P4 生成物の配置**:
 
@@ -1938,7 +1943,7 @@ TinyExpression は **Maven Central (OSSRH)** で公開される。
 
 | バージョン | リリース日 | 主な変更内容 |
 |----------|----------|------------|
-| **1.4.11** | 2026-04-21 | DSL バックエンド nested paren 乗算バグ修正（`(10-2)*(7-3)` 全 6 バックエンドパリティ達成）、`JavaCodeBlockPolicy` opt-out 追加（v1.4.11）、unlaxer-common/dsl 3.0.2 移行 |
+| **1.4.11** | 2026-04-21 | DSL バックエンド nested paren 乗算バグ修正（`(10-2)*(7-3)` 全 6 バックエンドパリティ達成）、`JavaCodeBlockPolicy` opt-out 追加（v1.4.11）、unlaxer-common/dsl 3.0.2 移行。その後 #49/#50/#51 で 3.0.11 に更新（packrat メモ化 default 有効化・corpus fallback 3→0） |
 | 1.4.10 | 2026-02-26 | P4TypedAstEvaluator を PRIMARY 昇格（ADR-001）、DAP デフォルト実行モードを `ast-evaluator` に変更、unlaxer-common 2.8.0 移行 |
 | 1.4.9 | 2026-02-25 | 文字列スライス（最後の機能ギャップ）、全 6 バックエンドフルパリティ達成、FormulaInfo LSP Phase 2、インクリメンタルパースキャッシュ LSP 統合 |
 | 1.4.8 | 2026-02-24 | `MethodInvocation` + `External` 呼び出しを `P4TypedAstEvaluator` でネイティブサポート（フォールバック排除）、バックエンドカバレッジマトリクス追加 |

--- a/specs/open-questions.md
+++ b/specs/open-questions.md
@@ -14,11 +14,13 @@
 
 ### 現在の UBNF カバレッジ
 
-2つの P4 UBNF が存在する:
-- `docs/ubnf/tinyexpression-p4-draft.ubnf`（239行、初期ドラフト）
-- `tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf`（321行、拡張版）
+P4 UBNF（権威は1つ、参照用が3つ）:
+- `tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf`（589行、**権威**・ビルド生成元）
+- `docs/ubnf/tinyexpression-p4-draft.ubnf`（239行、初期ドラフト・参照用）
+- `docs/ubnf/tinyexpression-p4-complete.ubnf`（548行、中間スナップショット・参照用）
+- `docs/ubnf/tinyexpression-p4-assoc-repro.ubnf`（24行、結合性再現用・参照用）
 
-拡張版は draft に対して CodeBlock、ImportDeclaration、ExternalInvocation、StringComparison 等を追加済み。
+権威版（tools/.../grammar/tinyexpression-p4.ubnf）は draft に対して CodeBlock、ImportDeclaration、ExternalInvocation、StringComparison 等を追加済み。
 
 ### レガシーパーサーとの差分（P4 UBNF に欠けている機能）
 

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -53,10 +53,11 @@ TinyExpression は **レガシーパーサー** と **P4 DSL 生成パーサー*
 
 ### P4 DSL 生成パーサー
 
-- `docs/ubnf/tinyexpression-p4-draft.ubnf` で UBNF 文法を定義
+- `tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf` で UBNF 文法を定義（589行・権威）
 - unlaxer-dsl により型安全なパーサー・AST・マッパーを自動生成
 - 段階的にレガシーパーサーの機能をカバー中
 - LSP/DAP サポートのベース
+- `docs/ubnf/` 配下の draft / complete / assoc-repro は歴史参照用（生成には使用しない）
 
 ## 6 つの実行バックエンド
 

--- a/specs/p4-grammar.md
+++ b/specs/p4-grammar.md
@@ -15,7 +15,8 @@
 
 - [language.md](language.md) — TinyExpression 言語仕様
 - [backends.md](backends.md) — P4 バックエンド
-- [docs/ubnf/tinyexpression-p4-draft.ubnf](../docs/ubnf/tinyexpression-p4-draft.ubnf) — P4 文法定義
+- [tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf](../tools/tinyexpression-p4-lsp-vscode/grammar/tinyexpression-p4.ubnf) — P4 文法定義（589行・権威・ビルド生成元）
+- [docs/ubnf/tinyexpression-p4-draft.ubnf](../docs/ubnf/tinyexpression-p4-draft.ubnf) — 初期ドラフト（239行・参照用・生成には使用しない）
 
 ---
 


### PR DESCRIPTION
## 対象 issue

Closes #59

## 変更概要

`spec/SPEC.md` および `specs/*.md` の unlaxer 依存バージョン・UBNF 行数・UBNF 参照パスが実態と乖離していたため更新。

## 事実確認

| 項目 | 旧（記載） | 実態 |
|------|----------|------|
| unlaxer-common/dsl バージョン | 3.0.2 | 3.0.11（`pom.xml:64,69`） |
| UBNF 行数 | 321行 | 589行（`tools/.../grammar/tinyexpression-p4.ubnf`） |
| UBNF 参照パス（specs/） | `docs/ubnf/tinyexpression-p4-draft.ubnf` | `tools/.../grammar/tinyexpression-p4.ubnf` |

## 変更内容

- **`spec/SPEC.md`**
  - 9.1: `unlaxer-common`/`unlaxer-dsl` 3.0.2 → 3.0.11
  - 9.3: バージョン移行履歴に #49/#50/#51 の 3.0.11 更新行を追加
  - 1.4 / 9.4 / 12.3: UBNF 行数 321 → 589
  - 9.4: P4 文法ファイル表に `complete`/`assoc-repro` を追加し、権威（`tools/.../grammar/...`）と参照用（`docs/ubnf/`）の役割を明記
- **`specs/open-questions.md`**: UBNF カバレッジを4ファイル記載に更新
- **`specs/overview.md`**: UBNF 参照を `docs/ubnf/draft` → `tools/.../grammar` に統一
- **`specs/p4-grammar.md`**: 関連ドキュメントの UBNF 参照を `tools/.../grammar` に更新

## 人間判断に委ねた事項（本 PR では実施しない）

- `docs/ubnf/` 配下の3ファイル（draft / complete / assoc-repro）を残すか削除するか。
  - 本 PR では**削除せず**、位置付け明記のみ行う（破壊的でない安全側）。
  - 整理は別 issue で人間判断予定。

## 影響範囲

- docs/specs のみ（コード変更なし、ビルド不要）

## 検証

- 4ファイルの編集
- 残存する `3.0.2` は意図的に履歴として残したもの（v1.4.11 の移行先、#49/#50/#51 での追加更新記述）
- リンク先ファイルの存在確認済み

## 関連

- 元監査レポート (2026-08-01) MEDIUM severity #3